### PR TITLE
Fix product image storage, tooltip display, and bulk delete

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\StoreProductRequest;
 use App\Http\Requests\UpdateProductRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use App\Models\Product;
 
 class ProductController extends Controller
 {
@@ -171,7 +172,7 @@ class ProductController extends Controller
 
     public function bulk(Request $request)
     {
-        $ids = $request->input('ids', []);
+        $ids = json_decode($request->input('ids', '[]'), true);
 
         if (!empty($ids)) {
             Product::whereIn('id', $ids)->delete();

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -152,7 +152,7 @@ class ProductService
 
         $created = new Collection();
         foreach ($files as $file) {
-            $path = $file->store('products', 'public');
+            $path = $file->store('products', ['disk' => 'public']);
             $created->push(
                 $product->images()->create(['path' => $path])
             );


### PR DESCRIPTION
## Summary
- use `asset()` for product and tooltip image URLs so they include domain
- allow tooltip to expand horizontally for product image previews
- store product uploads on the `public` disk so files land in `storage/app/public`
- switch to JavaScript-driven tooltips that render all product images side-by-side on hover
- decode bulk delete ID list and use the Product model to remove selected products

## Testing
- `composer install --no-interaction` *(fails: GitHub 403 requires token)*
- `php artisan test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8880a10483299600e874c3f648d5