### PR TITLE
Add admin category views and routes

### DIFF
--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -1,0 +1,84 @@
+@extends('layout.admin')
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="page-header">
+      <h3 class="page-title">Kategori</h3>
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="#">Katalog</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Tambah Kategori</li>
+        </ol>
+      </nav>
+    </div>
+
+    <div class="row">
+      <div class="col-12 grid-margin">
+        <div class="card">
+          <div class="card-body">
+            <h4 class="card-title">Tambah Kategori</h4>
+            <form class="form-sample" action="{{ route('admin.categories.store') }}" method="POST">
+              @csrf
+              <div class="row">
+                <div class="col-md-6">
+                  <div class="form-group row">
+                    <label class="col-sm-3 col-form-label">Nama</label>
+                    <div class="col-sm-9">
+                      <input type="text" name="name" id="category-name" class="form-control" value="{{ old('name') }}" required />
+                      @error('name') <small class="text-danger">{{ $message }}</small> @enderror
+                    </div>
+                  </div>
+                </div>
+                <div class="col-md-6">
+                  <div class="form-group row">
+                    <label class="col-sm-3 col-form-label">Slug</label>
+                    <div class="col-sm-9">
+                      <input type="text" name="slug" id="category-slug" class="form-control" value="{{ old('slug') }}" />
+                      <small class="form-text text-muted">Otomatis dari nama, bisa diedit.</small>
+                      @error('slug') <small class="text-danger">{{ $message }}</small> @enderror
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-12">
+                  <div class="form-group row">
+                    <label class="col-sm-2 col-form-label">Deskripsi</label>
+                    <div class="col-sm-10">
+                      <textarea name="description" class="form-control" rows="4">{{ old('description') }}</textarea>
+                      @error('description') <small class="text-danger">{{ $message }}</small> @enderror
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="row mt-4">
+                <div class="col-md-12 text-right">
+                  <a href="{{ route('admin.categories.index') }}" class="btn btn-secondary">Batal</a>
+                  <button type="submit" class="btn btn-primary">Simpan</button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+  (function() {
+    const nameInput = document.getElementById('category-name');
+    const slugInput = document.getElementById('category-slug');
+    if (nameInput && slugInput) {
+      nameInput.addEventListener('input', function(e) {
+        const val = e.target.value.trim().toLowerCase();
+        const slug = val.replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-');
+        slugInput.value = slug;
+      });
+    }
+  })();
+</script>
+@endsection

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -1,0 +1,85 @@
+@extends('layout.admin')
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="page-header">
+      <h3 class="page-title">Kategori</h3>
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="#">Katalog</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Edit Kategori</li>
+        </ol>
+      </nav>
+    </div>
+
+    <div class="row">
+      <div class="col-12 grid-margin">
+        <div class="card">
+          <div class="card-body">
+            <h4 class="card-title">Edit Kategori</h4>
+            <form class="form-sample" action="{{ route('admin.categories.update', $category->id) }}" method="POST">
+              @csrf
+              @method('PUT')
+              <div class="row">
+                <div class="col-md-6">
+                  <div class="form-group row">
+                    <label class="col-sm-3 col-form-label">Nama</label>
+                    <div class="col-sm-9">
+                      <input type="text" name="name" id="category-name" class="form-control" value="{{ old('name', $category->name) }}" required />
+                      @error('name') <small class="text-danger">{{ $message }}</small> @enderror
+                    </div>
+                  </div>
+                </div>
+                <div class="col-md-6">
+                  <div class="form-group row">
+                    <label class="col-sm-3 col-form-label">Slug</label>
+                    <div class="col-sm-9">
+                      <input type="text" name="slug" id="category-slug" class="form-control" value="{{ old('slug', $category->slug) }}" />
+                      <small class="form-text text-muted">Otomatis dari nama, bisa diedit.</small>
+                      @error('slug') <small class="text-danger">{{ $message }}</small> @enderror
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-12">
+                  <div class="form-group row">
+                    <label class="col-sm-2 col-form-label">Deskripsi</label>
+                    <div class="col-sm-10">
+                      <textarea name="description" class="form-control" rows="4">{{ old('description', $category->description) }}</textarea>
+                      @error('description') <small class="text-danger">{{ $message }}</small> @enderror
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="row mt-4">
+                <div class="col-md-12 text-right">
+                  <a href="{{ route('admin.categories.index') }}" class="btn btn-secondary">Batal</a>
+                  <button type="submit" class="btn btn-primary">Simpan</button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+  (function() {
+    const nameInput = document.getElementById('category-name');
+    const slugInput = document.getElementById('category-slug');
+    if (nameInput && slugInput) {
+      nameInput.addEventListener('input', function(e) {
+        const val = e.target.value.trim().toLowerCase();
+        const slug = val.replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-');
+        slugInput.value = slug;
+      });
+    }
+  })();
+</script>
+@endsection

--- a/resources/views/admin/categories/index.blade.php
+++ b/resources/views/admin/categories/index.blade.php
@@ -1,0 +1,69 @@
+@extends('layout.admin')
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="page-header">
+      <h3 class="page-title">Kategori</h3>
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="#">Katalog</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Kategori</li>
+        </ol>
+      </nav>
+    </div>
+
+    <div class="row">
+      <div class="col-lg-12 grid-margin stretch-card">
+        <div class="card">
+          <div class="card-body">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+              <div>
+                <h4 class="card-title mb-0">Daftar Kategori</h4>
+                <small class="text-muted">Kelola kategori produk</small>
+              </div>
+              <a href="{{ route('admin.categories.create') }}" class="btn btn-primary btn-sm">Tambah Kategori</a>
+            </div>
+
+            <div class="table-responsive">
+              <table class="table table-hover">
+                <thead>
+                  <tr>
+                    <th>Nama</th>
+                    <th>Slug</th>
+                    <th>Produk</th>
+                    <th style="width:130px">Aksi</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @forelse($categories as $category)
+                    <tr>
+                      <td>{{ $category->name }}</td>
+                      <td>{{ $category->slug }}</td>
+                      <td>{{ $category->products_count }}</td>
+                      <td>
+                        <div class="d-flex flex-nowrap" style="gap:4px;">
+                          <a href="{{ route('admin.categories.edit', $category->id) }}" class="btn btn-sm btn-primary" title="Edit"><i class="mdi mdi-pencil"></i></a>
+                          <form action="{{ route('admin.categories.destroy', $category->id) }}" method="POST" class="m-0" onsubmit="return confirm('Hapus kategori ini?');">
+                            @csrf
+                            @method('DELETE')
+                            <button class="btn btn-sm btn-danger" title="Hapus"><i class="mdi mdi-delete"></i></button>
+                          </form>
+                        </div>
+                      </td>
+                    </tr>
+                  @empty
+                    <tr>
+                      <td colspan="4" class="text-center">Kategori tidak ditemukan.</td>
+                    </tr>
+                  @endforelse
+                </tbody>
+              </table>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,11 +40,12 @@ Route::prefix('admin')/* ->middleware(['auth']) */->group(function () {
     Route::put('products/{id}/categories', [ProductController::class, 'syncCategories']);
 
     // categories
-    Route::get('categories', [CategoryController::class, 'index']);
-    Route::post('categories', [CategoryController::class, 'store']);
-    Route::get('categories/{id}', [CategoryController::class, 'show']);
-    Route::put('categories/{id}', [CategoryController::class, 'update']);
+    Route::get('categories', [CategoryController::class, 'index'])->name('admin.categories.index');
+    Route::get('categories/create', [CategoryController::class, 'create'])->name('admin.categories.create');
+    Route::post('categories', [CategoryController::class, 'store'])->name('admin.categories.store');
+    Route::get('categories/{id}/edit', [CategoryController::class, 'edit'])->name('admin.categories.edit');
+    Route::put('categories/{id}', [CategoryController::class, 'update'])->name('admin.categories.update');
     Route::patch('categories/{id}', [CategoryController::class, 'update']);
-    Route::delete('categories/{id}', [CategoryController::class, 'destroy']);
-    Route::get('categories/{id}/products', [CategoryController::class, 'products']);
+    Route::delete('categories/{id}', [CategoryController::class, 'destroy'])->name('admin.categories.destroy');
+    Route::get('categories/{id}/products', [CategoryController::class, 'products'])->name('admin.categories.products');
 });


### PR DESCRIPTION
## Summary
- Add admin category index view listing name, slug, product count with edit and delete actions
- Add category create and edit forms with fields for name, slug, description and slug auto-generation
- Name category routes and add create/edit endpoints

## Testing
- `composer install` *(fails: curl error 56 while downloading doctrine/inflector, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bed85174ac83298f088e2fa3ec9251