### PR TITLE
Add theme selection and dynamic home view

### DIFF
--- a/app/Http/Controllers/Admin/ThemeController.php
+++ b/app/Http/Controllers/Admin/ThemeController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Setting;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
+
+class ThemeController extends Controller
+{
+    public function index()
+    {
+        $themes = array_map('basename', File::directories(base_path('themes')));
+        $active = Setting::getValue('active_theme', 'theme-herbalgreen');
+        return view('admin.themes.index', compact('themes', 'active'));
+    }
+
+    public function update(Request $request)
+    {
+        $request->validate([
+            'theme' => 'required|string'
+        ]);
+
+        Setting::updateOrCreate(
+            ['key' => 'active_theme'],
+            ['value' => $request->input('theme')]
+        );
+
+        return redirect()->route('admin.themes.index')->with('success', 'Theme updated.');
+    }
+}
+

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    protected $fillable = ['key', 'value'];
+
+    public static function getValue(string $key, $default = null)
+    {
+        $setting = static::where('key', $key)->first();
+        return $setting ? $setting->value : $default;
+    }
+}
+

--- a/database/migrations/2025_09_05_140200_create_settings_table.php
+++ b/database/migrations/2025_09_05_140200_create_settings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};
+

--- a/resources/views/admin/themes/index.blade.php
+++ b/resources/views/admin/themes/index.blade.php
@@ -1,0 +1,33 @@
+@extends('layout.admin')
+
+@section('content')
+  <div class="main-panel">
+    <div class="content-wrapper">
+      <div class="row">
+        <div class="col-12 grid-margin stretch-card">
+          <div class="card">
+            <div class="card-body">
+              <h4 class="card-title">Pilih Tema</h4>
+              @if(session('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+              @endif
+              <form method="POST" action="{{ route('admin.themes.update') }}">
+                @csrf
+                <div class="form-group">
+                  <label for="theme">Tema</label>
+                  <select name="theme" id="theme" class="form-control">
+                    @foreach($themes as $theme)
+                      <option value="{{ $theme }}" {{ $active === $theme ? 'selected' : '' }}>{{ ucfirst(str_replace('theme-', '', $theme)) }}</option>
+                    @endforeach
+                  </select>
+                </div>
+                <button type="submit" class="btn btn-primary">Simpan</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection
+

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -82,6 +82,12 @@
               <span class="menu-title">Pengguna</span>
             </a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{url('/admin/themes')}}">
+              <i class="mdi mdi-palette menu-icon"></i>
+              <span class="menu-title">Tema</span>
+            </a>
+          </li>
           <li class="nav-item nav-category">Pembayaran & Pengiriman</li>
           <li class="nav-item">
             <a class="nav-link" href="{{url('/admin/payments')}}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,11 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\File;
 use App\Http\Controllers\Admin\ProductController;
 use App\Http\Controllers\Admin\CategoryController;
+use App\Http\Controllers\Admin\ThemeController;
+use App\Models\Setting;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,10 +19,19 @@ use App\Http\Controllers\Admin\CategoryController;
 */
 
 Route::get('/', function () {
-    return view('layout.admin');
+    $activeTheme = Setting::getValue('active_theme', 'theme-herbalgreen');
+    $viewPath = base_path("themes/{$activeTheme}/views/home.blade.php");
+    if (File::exists($viewPath)) {
+        return view()->file($viewPath, ['theme' => $activeTheme]);
+    }
+    abort(404);
 });
 
 Route::prefix('admin')/* ->middleware(['auth']) */->group(function () {
+    Route::get('/', function () {
+        return view('layout.admin');
+    });
+
     // products
     Route::get('products', [ProductController::class, 'index'])->name('admin.products.index');
     Route::get('products/create', [ProductController::class, 'create'])->name('admin.products.create');
@@ -30,7 +42,6 @@ Route::prefix('admin')/* ->middleware(['auth']) */->group(function () {
     Route::patch('products/{id}', [ProductController::class, 'update']);
     Route::delete('products/{id}', [ProductController::class, 'destroy'])->name('admin.products.destroy');
     Route::post('products/bulk', [ProductController::class, 'bulk'])->name('admin.products.bulk');
-
 
     Route::post('products/{id}/stock', [ProductController::class, 'updateStock']);
     Route::post('products/{id}/images', [ProductController::class, 'uploadImages']);
@@ -48,4 +59,8 @@ Route::prefix('admin')/* ->middleware(['auth']) */->group(function () {
     Route::patch('categories/{id}', [CategoryController::class, 'update']);
     Route::delete('categories/{id}', [CategoryController::class, 'destroy'])->name('admin.categories.destroy');
     Route::get('categories/{id}/products', [CategoryController::class, 'products'])->name('admin.categories.products');
+
+    // themes
+    Route::get('themes', [ThemeController::class, 'index'])->name('admin.themes.index');
+    Route::post('themes', [ThemeController::class, 'update'])->name('admin.themes.update');
 });

--- a/themes/theme-herbalgreen/views/home.blade.php
+++ b/themes/theme-herbalgreen/views/home.blade.php
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Herbal Green</title>
-    <link rel="stylesheet" href="{{ asset('themes/theme-herbalgreen/assets/theme.css') }}">
-    <script src="{{ asset('themes/theme-herbalgreen/assets/theme.js') }}" defer></script>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/assets/theme.css') }}">
+    <script src="{{ asset('themes/' . $theme . '/assets/theme.js') }}" defer></script>
 </head>
 <body>
 <header class="menu-bar">


### PR DESCRIPTION
## Summary
- add Setting model and migration to store active theme
- implement admin ThemeController with selection page
- render active theme on home route and link theme menu in sidebar

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/e-commerce/vendor/autoload.php')*
- `composer install` *(fails: requires GitHub token for downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c024ee772883299214985d0e750e60