### PR TITLE
Add home page element organizer with navigation/footer components

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+
+class PageController extends Controller
+{
+    public function home()
+    {
+        $sections = [
+            'topbar' => [
+                'label' => 'Shipping Bar',
+                'elements' => [
+                    ['type' => 'text', 'label' => 'Text'],
+                    ['type' => 'checkbox', 'label' => 'Show Bar'],
+                ],
+            ],
+            'navigation' => [
+                'label' => 'Navigation',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Homepage link', 'id' => 'hero'],
+                    ['type' => 'checkbox', 'label' => 'Tea Collection link', 'id' => 'products'],
+                    ['type' => 'checkbox', 'label' => 'News link', 'id' => 'testimonials'],
+                    ['type' => 'checkbox', 'label' => 'Contact Us link', 'id' => 'contact'],
+                ],
+            ],
+            'hero' => [
+                'label' => 'Hero',
+                'elements' => [
+                    ['type' => 'image', 'label' => 'Background Image'],
+                    ['type' => 'text', 'label' => 'Tagline'],
+                    ['type' => 'text', 'label' => 'Heading'],
+                    ['type' => 'textarea', 'label' => 'Description'],
+                    ['type' => 'text', 'label' => 'Button Label'],
+                    ['type' => 'text', 'label' => 'Button Link'],
+                ],
+            ],
+            'about' => [
+                'label' => 'About',
+                'elements' => [
+                    ['type' => 'text', 'label' => 'Heading'],
+                    ['type' => 'textarea', 'label' => 'Text'],
+                ],
+            ],
+            'products' => [
+                'label' => 'Products',
+                'elements' => [
+                    ['type' => 'text', 'label' => 'Heading'],
+                    ['type' => 'repeat', 'label' => 'Product cards'],
+                ],
+            ],
+            'services' => [
+                'label' => 'Services',
+                'elements' => [
+                    ['type' => 'text', 'label' => 'Heading'],
+                    ['type' => 'repeat', 'label' => 'Service items'],
+                ],
+            ],
+            'testimonials' => [
+                'label' => 'Testimonials',
+                'elements' => [
+                    ['type' => 'text', 'label' => 'Heading'],
+                    ['type' => 'repeat', 'label' => 'Testimonials list'],
+                ],
+            ],
+            'contact' => [
+                'label' => 'Contact',
+                'elements' => [
+                    ['type' => 'text', 'label' => 'Heading'],
+                    ['type' => 'form', 'label' => 'Form fields'],
+                ],
+            ],
+            'map' => [
+                'label' => 'Map',
+                'elements' => [
+                    ['type' => 'text', 'label' => 'Heading'],
+                    ['type' => 'map', 'label' => 'Embed code'],
+                ],
+            ],
+            'footer' => [
+                'label' => 'Footer',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Privacy Policy link'],
+                    ['type' => 'checkbox', 'label' => 'Terms & Conditions link'],
+                    ['type' => 'text', 'label' => 'Copyright Text'],
+                ],
+            ],
+        ];
+
+        return view('admin.pages.home', compact('sections'));
+    }
+}

--- a/resources/views/admin/pages/home.blade.php
+++ b/resources/views/admin/pages/home.blade.php
@@ -1,0 +1,67 @@
+@extends('layout.admin')
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="row">
+      <div class="col-md-4" id="elements">
+        @foreach ($sections as $key => $section)
+        <div class="card mb-3" data-section="{{ $key }}">
+          <div class="card-header">{{ $section['label'] }}</div>
+          <div class="card-body">
+            @foreach ($section['elements'] as $element)
+              <div class="form-group">
+                @if ($element['type'] === 'checkbox')
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" checked>
+                    <label class="form-check-label">{{ $element['label'] }}</label>
+                  </div>
+                @elseif ($element['type'] === 'text')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="text" class="form-control">
+                @elseif ($element['type'] === 'textarea')
+                  <label>{{ $element['label'] }}</label>
+                  <textarea class="form-control"></textarea>
+                @elseif ($element['type'] === 'image')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="file" class="form-control-file">
+                @else
+                  <p class="text-muted mb-0">{{ $element['label'] }}</p>
+                @endif
+              </div>
+            @endforeach
+          </div>
+        </div>
+        @endforeach
+      </div>
+      <div class="col-md-8">
+        <iframe id="page-preview" src="{{ url('/') }}" class="w-100 border" style="height:80vh"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+document.querySelectorAll('#elements .card').forEach(function(card){
+  card.addEventListener('mouseenter', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '2px dashed #ff9800';
+      section.scrollIntoView({behavior:'smooth'});
+    }
+  });
+  card.addEventListener('mouseleave', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '';
+    }
+  });
+});
+</script>
+@endsection

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -82,13 +82,19 @@
               <span class="menu-title">Pengguna</span>
             </a>
           </li>
-          <li class="nav-item">
-            <a class="nav-link" href="{{url('/admin/themes')}}">
-              <i class="mdi mdi-palette menu-icon"></i>
-              <span class="menu-title">Tema</span>
-            </a>
-          </li>
-          <li class="nav-item nav-category">Pembayaran & Pengiriman</li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{url('/admin/themes')}}">
+                <i class="mdi mdi-palette menu-icon"></i>
+                <span class="menu-title">Tema</span>
+              </a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{url('/admin/pages/home')}}">
+                <i class="mdi mdi-arrange-bring-forward menu-icon"></i>
+                <span class="menu-title">Home Organizer</span>
+              </a>
+            </li>
+            <li class="nav-item nav-category">Pembayaran & Pengiriman</li>
           <li class="nav-item">
             <a class="nav-link" href="{{url('/admin/payments')}}">
               <i class="mdi mdi-credit-card menu-icon"></i>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\ThemeAssetController;
 use App\Http\Controllers\Admin\ThemeController;
 use App\Http\Controllers\Admin\ProductController;
 use App\Http\Controllers\Admin\CategoryController;
+use App\Http\Controllers\Admin\PageController;
 
 /*
 |--------------------------------------------------------------------------
@@ -68,4 +69,6 @@ Route::prefix('admin')/* ->middleware(['auth']) */->group(function () {
     // themes
     Route::get('themes', [ThemeController::class, 'index'])->name('admin.themes.index');
     Route::post('themes', [ThemeController::class, 'update'])->name('admin.themes.update');
+
+    Route::get('pages/home', [PageController::class, 'home'])->name('admin.pages.home');
 });

--- a/themes/theme-herbalgreen/views/components/footer.blade.php
+++ b/themes/theme-herbalgreen/views/components/footer.blade.php
@@ -1,0 +1,10 @@
+<footer id="footer">
+    <ul class="footer-links">
+        @foreach ($links as $link)
+            @if ($link['visible'])
+                <li><a href="{{ $link['href'] }}">{{ $link['label'] }}</a></li>
+            @endif
+        @endforeach
+    </ul>
+    <p>&copy; {{ date('Y') }} Herbal Green</p>
+</footer>

--- a/themes/theme-herbalgreen/views/components/nav-menu.blade.php
+++ b/themes/theme-herbalgreen/views/components/nav-menu.blade.php
@@ -1,0 +1,17 @@
+<header id="navigation" class="site-header">
+    <div class="logo">TEA</div>
+    <nav class="main-nav">
+        <ul>
+            @foreach ($links as $link)
+                @if ($link['visible'])
+                    <li><a href="{{ $link['href'] }}">{{ $link['label'] }}</a></li>
+                @endif
+            @endforeach
+        </ul>
+    </nav>
+    <div class="header-icons">
+        <span>🔍</span>
+        <span>👤</span>
+        <span>🛒</span>
+    </div>
+</header>

--- a/themes/theme-herbalgreen/views/home.blade.php
+++ b/themes/theme-herbalgreen/views/home.blade.php
@@ -8,23 +8,21 @@
     <script src="{{ asset('themes/' . $theme . '/theme.js') }}" defer></script>
 </head>
 <body>
-<div class="shipping-bar">Free Worldwide Shipping</div>
-<header class="site-header">
-    <div class="logo">TEA</div>
-    <nav class="main-nav">
-        <ul>
-            <li><a href="#hero">Homepage</a></li>
-            <li><a href="#products">Tea Collection</a></li>
-            <li><a href="#testimonials">News</a></li>
-            <li><a href="#contact">Contact Us</a></li>
-        </ul>
-    </nav>
-    <div class="header-icons">
-        <span>🔍</span>
-        <span>👤</span>
-        <span>🛒</span>
-    </div>
-</header>
+@php
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => '#hero', 'visible' => true],
+        ['label' => 'Tea Collection', 'href' => '#products', 'visible' => true],
+        ['label' => 'News', 'href' => '#testimonials', 'visible' => true],
+        ['label' => 'Contact Us', 'href' => '#contact', 'visible' => true],
+    ];
+
+    $footerLinks = [
+        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => true],
+        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => true],
+    ];
+@endphp
+<div id="topbar" class="shipping-bar">Free Worldwide Shipping</div>
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
 
 <section id="hero" class="hero">
     <div class="hero-content">
@@ -91,8 +89,6 @@
     </div>
 </section>
 
-<footer>
-    <p>&copy; {{ date('Y') }} Herbal Green</p>
-</footer>
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), ['links' => $footerLinks])->render() !!}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Extract navigation bar and footer into reusable Blade components with configurable links.
- Introduce interactive admin Home Page organizer showing editable sections alongside a live preview.
- Register new admin route and sidebar link for quick access to the page organizer.

## Testing
- `phpunit` *(fails: command not found)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68c241f83e048329bcd06f7d79cbe900