### PR TITLE
Add product pages and shared components for storefront themes

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -119,4 +119,53 @@ class PageController extends Controller
 
         return response()->json(['status' => 'ok']);
     }
+
+    public function product()
+    {
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+        $settings = PageSetting::where('theme', $theme)->where('page', 'product')->pluck('value', 'key');
+
+        $sections = [
+            'hero' => [
+                'label' => 'Hero',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Show Section', 'id' => 'hero.visible'],
+                    ['type' => 'image', 'label' => 'Background Image', 'id' => 'hero.image'],
+                    ['type' => 'text', 'label' => 'Title', 'id' => 'title'],
+                ],
+            ],
+            'footer' => [
+                'label' => 'Footer',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Privacy Policy link', 'id' => 'footer.privacy'],
+                    ['type' => 'checkbox', 'label' => 'Terms & Conditions link', 'id' => 'footer.terms'],
+                    ['type' => 'text', 'label' => 'Copyright Text', 'id' => 'footer.copyright'],
+                ],
+            ],
+        ];
+
+        return view('admin.pages.product', compact('sections', 'settings'));
+    }
+
+    public function updateProduct(Request $request)
+    {
+        $request->validate([
+            'key' => 'required',
+            'value' => 'nullable',
+        ]);
+
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+
+        $value = $request->input('value');
+        if ($request->hasFile('value')) {
+            $value = $request->file('value')->store("pages/{$theme}", 'public');
+        }
+
+        PageSetting::updateOrCreate(
+            ['theme' => $theme, 'page' => 'product', 'key' => $request->input('key')],
+            ['value' => $value]
+        );
+
+        return response()->json(['status' => 'ok']);
+    }
 }

--- a/resources/views/admin/pages/product.blade.php
+++ b/resources/views/admin/pages/product.blade.php
@@ -1,0 +1,156 @@
+@extends('layout.admin')
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="row">
+      <div class="col-md-4" id="elements" style="max-height:100vh; overflow-y:auto;">
+        @foreach ($sections as $key => $section)
+        <div class="card mb-3" data-section="{{ $key }}">
+          <div class="card-header">{{ $section['label'] }}</div>
+          <div class="card-body">
+            @foreach ($section['elements'] as $element)
+                <div class="form-group">
+                  @if ($element['type'] === 'checkbox')
+                    <div class="form-check">
+                      <input class="form-check-input" type="checkbox" data-key="{{ $element['id'] }}" {{ ($settings[$element['id']] ?? '1') == '1' ? 'checked' : '' }}>
+                      <label class="form-check-label">{{ $element['label'] }}</label>
+                    </div>
+                  @elseif ($element['type'] === 'text')
+                    <label>{{ $element['label'] }}</label>
+                    <input type="text" class="form-control" data-key="{{ $element['id'] }}" value="{{ $settings[$element['id']] ?? '' }}">
+                  @elseif ($element['type'] === 'textarea')
+                    <label>{{ $element['label'] }}</label>
+                    <textarea class="form-control" data-key="{{ $element['id'] }}">{{ $settings[$element['id']] ?? '' }}</textarea>
+                  @elseif ($element['type'] === 'image')
+                    <label>{{ $element['label'] }}</label>
+                    <input type="file" class="form-control-file" data-key="{{ $element['id'] }}">
+                  @elseif ($element['type'] === 'repeatable')
+                    @php
+                      $items = json_decode($settings[$element['id']] ?? '[]', true);
+                      $fields = $element['fields'] ?? [];
+                    @endphp
+                    <div data-repeatable="{{ $element['id'] }}" data-fields='@json($fields)'>
+                      <div class="repeatable-items"></div>
+                      <button type="button" class="btn btn-sm btn-secondary add-item">Add Item</button>
+                      <textarea class="d-none" data-key="{{ $element['id'] }}">{{ json_encode($items) }}</textarea>
+                    </div>
+                  @else
+                    <p class="text-muted mb-0">{{ $element['label'] }}</p>
+                  @endif
+                </div>
+                @endforeach
+              </div>
+            </div>
+            @endforeach
+      </div>
+      <div class="col-md-8 position-sticky" style="top:0;height:100vh">
+        <iframe id="page-preview" src="{{ url('/produk') }}" class="w-100 border h-100"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+const csrf = '{{ csrf_token() }}';
+
+document.querySelectorAll('#elements [data-key]').forEach(function(input){
+  input.addEventListener('change', function(){
+    const key = this.getAttribute('data-key');
+    const formData = new FormData();
+    formData.append('key', key);
+    if(this.type === 'checkbox'){
+      formData.append('value', this.checked ? 1 : 0);
+    }else if(this.type === 'file'){
+      if(this.files[0]){ formData.append('value', this.files[0]); }
+    }else{
+      formData.append('value', this.value);
+    }
+    fetch('{{ route('admin.pages.product.update') }}', {
+      method: 'POST',
+      headers: {'X-CSRF-TOKEN': csrf},
+      body: formData
+    }).then(() => {
+      document.getElementById('page-preview').contentWindow.location.reload();
+    });
+  });
+});
+
+document.querySelectorAll('[data-repeatable]').forEach(function(wrapper){
+  const itemsContainer = wrapper.querySelector('.repeatable-items');
+  const hidden = wrapper.querySelector('[data-key]');
+  const fields = JSON.parse(wrapper.getAttribute('data-fields') || '[]');
+
+  function buildItem(data = {}){
+    const div = document.createElement('div');
+    div.className = 'repeatable-item mb-2';
+    let html = '';
+    fields.forEach(function(field){
+      if((field.type || 'text') === 'textarea'){
+        html += `<textarea class="form-control mb-1" data-field="${field.name}" placeholder="${field.placeholder}">${data[field.name] || ''}</textarea>`;
+      }else{
+        html += `<input type="text" class="form-control mb-1" data-field="${field.name}" placeholder="${field.placeholder}" value="${data[field.name] || ''}">`;
+      }
+    });
+    html += '<button type="button" class="btn btn-sm btn-danger remove-item">Remove</button>';
+    div.innerHTML = html;
+    return div;
+  }
+
+  function sync(){
+    const data = [];
+    itemsContainer.querySelectorAll('.repeatable-item').forEach(function(item){
+      const obj = {};
+      item.querySelectorAll('[data-field]').forEach(function(input){
+        obj[input.getAttribute('data-field')] = input.value;
+      });
+      data.push(obj);
+    });
+    hidden.value = JSON.stringify(data);
+    hidden.dispatchEvent(new Event('change'));
+  }
+
+  wrapper.querySelector('.add-item').addEventListener('click', function(){
+    itemsContainer.appendChild(buildItem());
+  });
+
+  itemsContainer.addEventListener('input', sync);
+  itemsContainer.addEventListener('click', function(e){
+    if(e.target.classList.contains('remove-item')){
+      e.target.closest('.repeatable-item').remove();
+      sync();
+    }
+  });
+
+  // initialize existing
+  try {
+    JSON.parse(hidden.value || '[]').forEach(function(item){
+      itemsContainer.appendChild(buildItem(item));
+    });
+  } catch(e) {}
+  sync();
+});
+
+document.querySelectorAll('#elements .card').forEach(function(card){
+  card.addEventListener('mouseenter', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '2px dashed #ff9800';
+      section.scrollIntoView({behavior:'smooth'});
+    }
+  });
+  card.addEventListener('mouseleave', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '';
+    }
+  });
+});
+</script>
+@endsection

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -97,6 +97,7 @@
               <div class="collapse" id="pages-menu">
                 <ul class="nav flex-column sub-menu">
                   <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/home')}}">Home</a></li>
+                  <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/product')}}">Produk</a></li>
                 </ul>
               </div>
             </li>

--- a/resources/views/themes/second/home.blade.php
+++ b/resources/views/themes/second/home.blade.php
@@ -33,40 +33,7 @@
     $aboutImage = $settings['about.image'] ?? null;
 @endphp
 
-<header class="header">
-    <div class="container">
-        <div class="row">
-            <div class="col-lg-3">
-                <div class="header__logo">
-                    <a href="{{ url('/') }}"><img src="{{ asset('ogani-master/img/logo.png') }}" alt=""></a>
-                </div>
-            </div>
-            <div class="col-lg-6">
-                <nav class="header__menu">
-                    <ul>
-                        @foreach($navLinks as $link)
-                            @if($link['visible'])
-                                <li><a href="{{ $link['href'] }}">{{ $link['label'] }}</a></li>
-                            @endif
-                        @endforeach
-                    </ul>
-                </nav>
-            </div>
-            <div class="col-lg-3">
-                <div class="header__cart">
-                    <ul>
-                        <li><a href="#"><i class="fa fa-heart"></i> <span>0</span></a></li>
-                        <li><a href="#"><i class="fa fa-shopping-bag"></i> <span>0</span></a></li>
-                    </ul>
-                    <div class="header__cart__price">item: <span>$0.00</span></div>
-                </div>
-            </div>
-        </div>
-        <div class="humberger__open">
-            <i class="fa fa-bars"></i>
-        </div>
-    </div>
-</header>
+{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
 
 @if(($settings['hero.visible'] ?? '1') == '1')
 <section id="hero" class="hero">
@@ -232,6 +199,8 @@
     @endif
 </div>
 @endif
+
+{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
 
 <script src="{{ asset('ogani-master/js/jquery-3.3.1.min.js') }}"></script>
 <script src="{{ asset('ogani-master/js/bootstrap.min.js') }}"></script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,15 @@ Route::get('/', function () {
     abort(404);
 });
 
+Route::get('/produk', function () {
+    $activeTheme = Setting::getValue('active_theme', 'theme-herbalgreen');
+    $viewPath = base_path("themes/{$activeTheme}/views/product.blade.php");
+    if (File::exists($viewPath)) {
+        return view()->file($viewPath, ['theme' => $activeTheme]);
+    }
+    abort(404);
+})->name('products.index');
+
 Route::get('themes/{theme}/assets/{path}', ThemeAssetController::class)
     ->where('path', '.*')
     ->name('themes.assets');
@@ -72,4 +81,6 @@ Route::prefix('admin')/* ->middleware(['auth']) */->group(function () {
 
     Route::get('pages/home', [PageController::class, 'home'])->name('admin.pages.home');
     Route::post('pages/home', [PageController::class, 'updateHome'])->name('admin.pages.home.update');
+    Route::get('pages/product', [PageController::class, 'product'])->name('admin.pages.product');
+    Route::post('pages/product', [PageController::class, 'updateProduct'])->name('admin.pages.product.update');
 });

--- a/themes/theme-herbalgreen/views/product.blade.php
+++ b/themes/theme-herbalgreen/views/product.blade.php
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Produk</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+    <script src="{{ asset('themes/' . $theme . '/theme.js') }}" defer></script>
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Models\Product;
+    use App\Models\Category;
+    $settings = PageSetting::where('theme', $theme)->where('page', 'product')->pluck('value', 'key')->toArray();
+    $query = Product::query();
+    if($s = request('search')){ $query->where('name', 'like', "%$s%"); }
+    if($cat = request('category')){ $query->whereHas('categories', fn($q) => $q->where('slug', $cat)); }
+    if($sort = request('sort')){
+        if($sort === 'price_asc') $query->orderBy('price');
+        elseif($sort === 'price_desc') $query->orderByDesc('price');
+        elseif($sort === 'sold_desc') $query->withCount('orderItems')->orderByDesc('order_items_count');
+    }
+    $products = $query->paginate(15)->withQueryString();
+    $categories = Category::all();
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+    ];
+@endphp
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+@if(($settings['hero.visible'] ?? '1') == '1')
+<section id="hero" class="hero" @if(!empty($settings['hero.image'])) style="background-image:url('{{ asset('storage/'.$settings['hero.image']) }}')" @endif>
+    <div class="hero-content">
+        <h1>{{ $settings['title'] ?? 'Produk Kami' }}</h1>
+    </div>
+</section>
+@endif
+<section class="product-search">
+    <form method="GET">
+        <input type="text" name="search" placeholder="Cari Produk..." value="{{ request('search') }}">
+        <select name="category">
+            <option value="">Semua Kategori</option>
+            @foreach($categories as $category)
+                <option value="{{ $category->slug }}" @selected(request('category')==$category->slug)>{{ $category->name }}</option>
+            @endforeach
+        </select>
+        <select name="sort">
+            <option value="">Urutkan</option>
+            <option value="price_asc" @selected(request('sort')=='price_asc')>Harga Terendah</option>
+            <option value="price_desc" @selected(request('sort')=='price_desc')>Harga Tertinggi</option>
+            <option value="sold_desc" @selected(request('sort')=='sold_desc')>Terjual Terbanyak</option>
+        </select>
+        <button type="submit">Filter</button>
+    </form>
+</section>
+<section id="products" class="products">
+    <div class="product-grid">
+        @foreach($products as $product)
+            <div class="product-card">
+                @php $img = optional($product->images()->first())->path; @endphp
+                <img src="{{ $img ? asset('storage/'.$img) : 'https://via.placeholder.com/150' }}" alt="{{ $product->name }}">
+                <h3>{{ $product->name }}</h3>
+                <p>{{ $product->price_formatted ?? number_format($product->price,0,',','.') }}</p>
+                <a href="{{ url('products/'.$product->id) }}" class="btn">Detail</a>
+            </div>
+        @endforeach
+    </div>
+    <div class="pagination">
+        {{ $products->links() }}
+    </div>
+</section>
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), ['links' => [], 'copyright' => $settings['footer.copyright'] ?? ('© '.date('Y'))])->render() !!}
+</body>
+</html>

--- a/themes/theme-restoran/views/components/footer.blade.php
+++ b/themes/theme-restoran/views/components/footer.blade.php
@@ -1,0 +1,62 @@
+<div class="container-fluid bg-dark text-light footer pt-5 mt-5 wow fadeIn" data-wow-delay="0.1s">
+    <div class="container py-5">
+        <div class="row g-5">
+            <div class="col-lg-3 col-md-6">
+                <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Company</h4>
+                <a class="btn btn-link" href="#">About Us</a>
+                <a class="btn btn-link" href="#">Contact Us</a>
+                <a class="btn btn-link" href="#">Reservation</a>
+                <a class="btn btn-link" href="#">Privacy Policy</a>
+                <a class="btn btn-link" href="#">Terms & Condition</a>
+            </div>
+            <div class="col-lg-3 col-md-6">
+                <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Contact</h4>
+                <p class="mb-2"><i class="fa fa-map-marker-alt me-3"></i>123 Street, New York, USA</p>
+                <p class="mb-2"><i class="fa fa-phone-alt me-3"></i>+012 345 67890</p>
+                <p class="mb-2"><i class="fa fa-envelope me-3"></i>info@example.com</p>
+                <div class="d-flex pt-2">
+                    <a class="btn btn-outline-light btn-social" href="#"><i class="fab fa-twitter"></i></a>
+                    <a class="btn btn-outline-light btn-social" href="#"><i class="fab fa-facebook-f"></i></a>
+                    <a class="btn btn-outline-light btn-social" href="#"><i class="fab fa-youtube"></i></a>
+                    <a class="btn btn-outline-light btn-social" href="#"><i class="fab fa-linkedin-in"></i></a>
+                </div>
+            </div>
+            <div class="col-lg-3 col-md-6">
+                <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Opening</h4>
+                <h5 class="text-light fw-normal">Monday - Saturday</h5>
+                <p>09AM - 09PM</p>
+                <h5 class="text-light fw-normal">Sunday</h5>
+                <p>10AM - 08PM</p>
+            </div>
+            <div class="col-lg-3 col-md-6">
+                <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Newsletter</h4>
+                <p>Dolor amet sit justo amet elitr clita ipsum elitr est.</p>
+                <div class="position-relative mx-auto" style="max-width: 400px;">
+                    <input class="form-control border-primary w-100 py-3 ps-4 pe-5" type="text" placeholder="Your email">
+                    <button type="button" class="btn btn-primary py-2 position-absolute top-0 end-0 mt-2 me-2">SignUp</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="container">
+        <div class="copyright">
+            <div class="row">
+                <div class="col-md-6 text-center text-md-start mb-3 mb-md-0">
+                    {{ $settings['footer.copyright'] ?? '© ' . date('Y') . ' Restoran' }}
+                    @if(($settings['footer.privacy'] ?? '0') == '1') | <a class="border-bottom" href="#">Privacy Policy</a>@endif
+                    @if(($settings['footer.terms'] ?? '0') == '1') | <a class="border-bottom" href="#">Terms & Conditions</a>@endif
+                    <br>Designed By <a class="border-bottom" href="https://htmlcodex.com">HTML Codex</a><br>
+                    Distributed By <a class="border-bottom" href="https://themewagon.com" target="_blank">ThemeWagon</a>
+                </div>
+                <div class="col-md-6 text-center text-md-end">
+                    <div class="footer-menu">
+                        <a href="#">Home</a>
+                        <a href="#">Cookies</a>
+                        <a href="#">Help</a>
+                        <a href="#">FQAs</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/themes/theme-restoran/views/components/nav-menu.blade.php
+++ b/themes/theme-restoran/views/components/nav-menu.blade.php
@@ -1,0 +1,18 @@
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark px-4 px-lg-5 py-3 py-lg-0">
+    <a href="{{ url('/') }}" class="navbar-brand p-0">
+        <h1 class="text-primary m-0"><i class="fa fa-utensils me-3"></i>Restoran</h1>
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse">
+        <span class="fa fa-bars"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarCollapse">
+        <div class="navbar-nav ms-auto py-0 pe-4">
+            @foreach($links as $link)
+                @if($link['visible'])
+                    <a href="{{ $link['href'] }}" class="nav-item nav-link">{{ $link['label'] }}</a>
+                @endif
+            @endforeach
+        </div>
+        <a href="#" class="btn btn-primary py-2 px-4">Book A Table</a>
+    </div>
+</nav>

--- a/themes/theme-restoran/views/home.blade.php
+++ b/themes/theme-restoran/views/home.blade.php
@@ -42,24 +42,7 @@
     $aboutImage = $settings['about.image'] ?? null;
 @endphp
 <div class="container-xxl position-relative p-0">
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark px-4 px-lg-5 py-3 py-lg-0">
-        <a href="{{ url('/') }}" class="navbar-brand p-0">
-            <h1 class="text-primary m-0"><i class="fa fa-utensils me-3"></i>Restoran</h1>
-        </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse">
-            <span class="fa fa-bars"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarCollapse">
-            <div class="navbar-nav ms-auto py-0 pe-4">
-                @foreach($navLinks as $link)
-                    @if($link['visible'])
-                        <a href="{{ $link['href'] }}" class="nav-item nav-link">{{ $link['label'] }}</a>
-                    @endif
-                @endforeach
-            </div>
-            <a href="#" class="btn btn-primary py-2 px-4">Book A Table</a>
-        </div>
-    </nav>
+    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
     @if(($settings['hero.visible'] ?? '1') == '1')
     <div id="hero" class="container-xxl py-5 bg-dark hero-header mb-5">
         <div class="container my-5 py-5">
@@ -228,13 +211,7 @@
     </div>
 </div>
 @endif
-<footer class="bg-dark text-light pt-5 mt-5">
-    <div class="container">
-        <div class="text-center">
-            <p>{{ $settings['footer.copyright'] ?? '© '.date('Y').' Restoran' }}@if(($settings['footer.privacy'] ?? '0') == '1') | <a href="#" class="text-light">Privacy Policy</a>@endif @if(($settings['footer.terms'] ?? '0') == '1') | <a href="#" class="text-light">Terms & Conditions</a>@endif</p>
-        </div>
-    </div>
-</footer>
+{!! view()->file(base_path('themes/theme-restoran/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
 <a href="#" class="btn btn-lg btn-primary btn-lg-square back-to-top"><i class="bi bi-arrow-up"></i></a>
 <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/themes/theme-second/views/components/footer.blade.php
+++ b/themes/theme-second/views/components/footer.blade.php
@@ -1,0 +1,63 @@
+<footer class="footer spad">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-3 col-md-6 col-sm-6">
+                <div class="footer__about">
+                    <div class="footer__about__logo">
+                        <a href="{{ url('/') }}"><img src="{{ asset('ogani-master/img/logo.png') }}" alt=""></a>
+                    </div>
+                    <ul>
+                        <li>Address: 60-49 Road 11378 New York</li>
+                        <li>Phone: +65 11.188.888</li>
+                        <li>Email: hello@colorlib.com</li>
+                    </ul>
+                </div>
+            </div>
+            <div class="col-lg-4 col-md-6 col-sm-6 offset-lg-1">
+                <div class="footer__widget">
+                    <h6>Useful Links</h6>
+                    <ul>
+                        <li><a href="#">About Us</a></li>
+                        <li><a href="#">About Our Shop</a></li>
+                        <li><a href="#">Secure Shopping</a></li>
+                        <li><a href="#">Delivery infomation</a></li>
+                        <li><a href="#">Privacy Policy</a></li>
+                        <li><a href="#">Our Sitemap</a></li>
+                    </ul>
+                    <ul>
+                        <li><a href="#">Who We Are</a></li>
+                        <li><a href="#">Our Services</a></li>
+                        <li><a href="#">Projects</a></li>
+                        <li><a href="#">Contact</a></li>
+                        <li><a href="#">Innovation</a></li>
+                        <li><a href="#">Testimonials</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="col-lg-4 col-md-12">
+                <div class="footer__widget">
+                    <h6>Join Our Newsletter Now</h6>
+                    <p>Get E-mail updates about our latest shop and special offers.</p>
+                    <form action="#">
+                        <input type="text" placeholder="Enter your mail">
+                        <button type="submit" class="site-btn">Subscribe</button>
+                    </form>
+                    <div class="footer__widget__social">
+                        <a href="#"><i class="fa fa-facebook"></i></a>
+                        <a href="#"><i class="fa fa-instagram"></i></a>
+                        <a href="#"><i class="fa fa-twitter"></i></a>
+                        <a href="#"><i class="fa fa-pinterest"></i></a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="footer__copyright">
+                    <div class="footer__copyright__text"><p>{{ $settings['footer.copyright'] ?? 'Copyright &copy; '.date('Y').' All rights reserved' }}@if(($settings['footer.privacy'] ?? '0') == '1') | <a href="#">Privacy Policy</a>@endif @if(($settings['footer.terms'] ?? '0') == '1') | <a href="#">Terms & Conditions</a>@endif</p></div>
+                    <div class="footer__copyright__payment"><img src="{{ asset('ogani-master/img/payment-item.png') }}" alt=""></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/themes/theme-second/views/components/nav-menu.blade.php
+++ b/themes/theme-second/views/components/nav-menu.blade.php
@@ -1,0 +1,34 @@
+<header class="header">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-3">
+                <div class="header__logo">
+                    <a href="{{ url('/') }}"><img src="{{ asset('ogani-master/img/logo.png') }}" alt=""></a>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <nav class="header__menu">
+                    <ul>
+                        @foreach($links as $link)
+                            @if($link['visible'])
+                                <li><a href="{{ $link['href'] }}">{{ $link['label'] }}</a></li>
+                            @endif
+                        @endforeach
+                    </ul>
+                </nav>
+            </div>
+            <div class="col-lg-3">
+                <div class="header__cart">
+                    <ul>
+                        <li><a href="#"><i class="fa fa-heart"></i> <span>0</span></a></li>
+                        <li><a href="#"><i class="fa fa-shopping-bag"></i> <span>0</span></a></li>
+                    </ul>
+                    <div class="header__cart__price">item: <span>$0.00</span></div>
+                </div>
+            </div>
+        </div>
+        <div class="humberger__open">
+            <i class="fa fa-bars"></i>
+        </div>
+    </div>
+</header>

--- a/themes/theme-second/views/home.blade.php
+++ b/themes/theme-second/views/home.blade.php
@@ -32,41 +32,7 @@
     ];
     $aboutImage = $settings['about.image'] ?? null;
 @endphp
-
-<header class="header">
-    <div class="container">
-        <div class="row">
-            <div class="col-lg-3">
-                <div class="header__logo">
-                    <a href="{{ url('/') }}"><img src="{{ asset('ogani-master/img/logo.png') }}" alt=""></a>
-                </div>
-            </div>
-            <div class="col-lg-6">
-                <nav class="header__menu">
-                    <ul>
-                        @foreach($navLinks as $link)
-                            @if($link['visible'])
-                                <li><a href="{{ $link['href'] }}">{{ $link['label'] }}</a></li>
-                            @endif
-                        @endforeach
-                    </ul>
-                </nav>
-            </div>
-            <div class="col-lg-3">
-                <div class="header__cart">
-                    <ul>
-                        <li><a href="#"><i class="fa fa-heart"></i> <span>0</span></a></li>
-                        <li><a href="#"><i class="fa fa-shopping-bag"></i> <span>0</span></a></li>
-                    </ul>
-                    <div class="header__cart__price">item: <span>$0.00</span></div>
-                </div>
-            </div>
-        </div>
-        <div class="humberger__open">
-            <i class="fa fa-bars"></i>
-        </div>
-    </div>
-</header>
+{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
 
 @if(($settings['hero.visible'] ?? '1') == '1')
 <section id="hero" class="hero">
@@ -239,69 +205,7 @@
 </section>
 @endif
 
-<footer class="footer spad">
-    <div class="container">
-        <div class="row">
-            <div class="col-lg-3 col-md-6 col-sm-6">
-                <div class="footer__about">
-                    <div class="footer__about__logo">
-                        <a href="{{ url('/') }}"><img src="{{ asset('ogani-master/img/logo.png') }}" alt=""></a>
-                    </div>
-                    <ul>
-                        <li>Address: 60-49 Road 11378 New York</li>
-                        <li>Phone: +65 11.188.888</li>
-                        <li>Email: hello@colorlib.com</li>
-                    </ul>
-                </div>
-            </div>
-            <div class="col-lg-4 col-md-6 col-sm-6 offset-lg-1">
-                <div class="footer__widget">
-                    <h6>Useful Links</h6>
-                    <ul>
-                        <li><a href="#">About Us</a></li>
-                        <li><a href="#">About Our Shop</a></li>
-                        <li><a href="#">Secure Shopping</a></li>
-                        <li><a href="#">Delivery infomation</a></li>
-                        <li><a href="#">Privacy Policy</a></li>
-                        <li><a href="#">Our Sitemap</a></li>
-                    </ul>
-                    <ul>
-                        <li><a href="#">Who We Are</a></li>
-                        <li><a href="#">Our Services</a></li>
-                        <li><a href="#">Projects</a></li>
-                        <li><a href="#">Contact</a></li>
-                        <li><a href="#">Innovation</a></li>
-                        <li><a href="#">Testimonials</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div class="col-lg-4 col-md-12">
-                <div class="footer__widget">
-                    <h6>Join Our Newsletter Now</h6>
-                    <p>Get E-mail updates about our latest shop and special offers.</p>
-                    <form action="#">
-                        <input type="text" placeholder="Enter your mail">
-                        <button type="submit" class="site-btn">Subscribe</button>
-                    </form>
-                    <div class="footer__widget__social">
-                        <a href="#"><i class="fa fa-facebook"></i></a>
-                        <a href="#"><i class="fa fa-instagram"></i></a>
-                        <a href="#"><i class="fa fa-twitter"></i></a>
-                        <a href="#"><i class="fa fa-pinterest"></i></a>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-lg-12">
-                <div class="footer__copyright">
-                    <div class="footer__copyright__text"><p>{{ $settings['footer.copyright'] ?? 'Copyright &copy; '.date('Y').' All rights reserved' }}@if(($settings['footer.privacy'] ?? '0') == '1') | <a href="#">Privacy Policy</a>@endif @if(($settings['footer.terms'] ?? '0') == '1') | <a href="#">Terms & Conditions</a>@endif</p></div>
-                    <div class="footer__copyright__payment"><img src="{{ asset('ogani-master/img/payment-item.png') }}" alt=""></div>
-                </div>
-            </div>
-        </div>
-    </div>
-</footer>
+{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
 
 <script src="{{ asset('ogani-master/js/jquery-3.3.1.min.js') }}"></script>
 <script src="{{ asset('ogani-master/js/bootstrap.min.js') }}"></script>

--- a/themes/theme-second/views/product.blade.php
+++ b/themes/theme-second/views/product.blade.php
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Produk</title>
+    <link rel="stylesheet" href="{{ asset('ogani-master/css/bootstrap.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('ogani-master/css/font-awesome.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('ogani-master/css/elegant-icons.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('ogani-master/css/nice-select.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('ogani-master/css/jquery-ui.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('ogani-master/css/owl.carousel.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('ogani-master/css/slicknav.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('ogani-master/css/style.css') }}" type="text/css">
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Models\Product;
+    use App\Models\Category;
+    $settings = PageSetting::where('theme', 'theme-second')->where('page', 'product')->pluck('value', 'key')->toArray();
+    $query = Product::query();
+    if($s = request('search')){ $query->where('name','like',"%$s%"); }
+    if($cat = request('category')){ $query->whereHas('categories', fn($q)=>$q->where('slug',$cat)); }
+    if($min = request('minprice')){ $query->where('price', '>=', $min); }
+    if($max = request('maxprice')){ $query->where('price', '<=', $max); }
+    if($sort = request('sort')){
+        if($sort==='price_asc') $query->orderBy('price');
+        elseif($sort==='price_desc') $query->orderByDesc('price');
+        elseif($sort==='sold_desc') $query->withCount('orderItems')->orderByDesc('order_items_count');
+    }
+    $products = $query->paginate(15)->withQueryString();
+    $categories = Category::all();
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+    ];
+@endphp
+{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+<section class="breadcrumb-section set-bg" data-setbg="{{ !empty($settings['hero.image']) ? asset('storage/'.$settings['hero.image']) : asset('ogani-master/img/breadcrumb.jpg') }}">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <div class="breadcrumb__text">
+                    <h2>{{ $settings['title'] ?? 'Produk Kami' }}</h2>
+                    <div class="breadcrumb__option">
+                        <a href="{{ url('/') }}">Home</a>
+                        <span>{{ $settings['title'] ?? 'Produk Kami' }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="product spad">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-3 col-md-5">
+                <div class="sidebar">
+                    <form method="GET" id="sidebar-form">
+                        <div class="sidebar__item">
+                            <h4>Pencarian</h4>
+                            <div class="hero__search__form">
+                                <input type="text" name="search" placeholder="Cari Produk..." value="{{ request('search') }}">
+                                <button type="submit" class="site-btn">SEARCH</button>
+                            </div>
+                        </div>
+                        <div class="sidebar__item">
+                            <h4>Kategori</h4>
+                            <ul>
+                                <li class="{{ request('category') ? '' : 'active' }}"><a href="#" onclick="event.preventDefault();document.getElementById('category').value='';document.getElementById('sidebar-form').submit();">Semua</a></li>
+                                @foreach($categories as $cat)
+                                    <li class="{{ request('category')==$cat->slug ? 'active' : '' }}"><a href="#" onclick="event.preventDefault();document.getElementById('category').value='{{ $cat->slug }}';document.getElementById('sidebar-form').submit();">{{ $cat->name }}</a></li>
+                                @endforeach
+                            </ul>
+                            <input type="hidden" id="category" name="category" value="{{ request('category') }}">
+                        </div>
+                        <div class="sidebar__item">
+                            <h4>Harga</h4>
+                            <div class="price-range-wrap">
+                                <div id="price-range" class="price-range"></div>
+                                <div class="range-slider">
+                                    <div class="price-input">
+                                        <input type="text" id="minamount" name="minprice" value="{{ request('minprice',0) }}">
+                                        <input type="text" id="maxamount" name="maxprice" value="{{ request('maxprice',1000000) }}">
+                                    </div>
+                                    <button type="submit" class="site-btn mt-3">Filter</button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <div class="col-lg-9 col-md-7">
+                <div class="filter__item">
+                    <div class="row">
+                        <div class="col-lg-4 col-md-5">
+                            <div class="filter__sort">
+                                <span>Sort By</span>
+                                <form method="GET" id="sort-form">
+                                    <input type="hidden" name="search" value="{{ request('search') }}">
+                                    <input type="hidden" name="category" value="{{ request('category') }}">
+                                    <input type="hidden" name="minprice" value="{{ request('minprice') }}">
+                                    <input type="hidden" name="maxprice" value="{{ request('maxprice') }}">
+                                    <select name="sort" onchange="document.getElementById('sort-form').submit()">
+                                        <option value="">Default</option>
+                                        <option value="price_asc" @selected(request('sort')=='price_asc')>Harga Terendah</option>
+                                        <option value="price_desc" @selected(request('sort')=='price_desc')>Harga Tertinggi</option>
+                                        <option value="sold_desc" @selected(request('sort')=='sold_desc')>Terjual Terbanyak</option>
+                                    </select>
+                                </form>
+                            </div>
+                        </div>
+                        <div class="col-lg-8 col-md-7">
+                            <div class="filter__found">
+                                <h6><span>{{ $products->total() }}</span> Produk ditemukan</h6>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    @foreach($products as $product)
+                        @php $img = $product->image_url ?? optional($product->images()->first())->path; @endphp
+                        <div class="col-lg-4 col-md-6 col-sm-6">
+                            <div class="product__item">
+                                <div class="product__item__pic set-bg" data-setbg="{{ $img ? asset('storage/'.$img) : asset('ogani-master/img/product/product-1.jpg') }}">
+                                    <ul class="product__item__pic__hover">
+                                        <li><a href="#"><i class="fa fa-heart"></i></a></li>
+                                        <li><a href="#"><i class="fa fa-retweet"></i></a></li>
+                                        <li><a href="#"><i class="fa fa-shopping-cart"></i></a></li>
+                                    </ul>
+                                </div>
+                                <div class="product__item__text">
+                                    <h6><a href="{{ url('products/'.$product->id) }}">{{ $product->name }}</a></h6>
+                                    <h5>{{ $product->price_formatted ?? number_format($product->price,0,',','.') }}</h5>
+                                </div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+                <div class="product__pagination">
+                    {{ $products->links() }}
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+<script src="{{ asset('ogani-master/js/jquery-3.3.1.min.js') }}"></script>
+<script src="{{ asset('ogani-master/js/bootstrap.min.js') }}"></script>
+<script src="{{ asset('ogani-master/js/jquery.nice-select.min.js') }}"></script>
+<script src="{{ asset('ogani-master/js/jquery-ui.min.js') }}"></script>
+<script src="{{ asset('ogani-master/js/jquery.slicknav.js') }}"></script>
+<script src="{{ asset('ogani-master/js/mixitup.min.js') }}"></script>
+<script src="{{ asset('ogani-master/js/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('ogani-master/js/main.js') }}"></script>
+<script>
+    $(function(){
+        var min = {{ request('minprice',0) }};
+        var max = {{ request('maxprice',1000000) }};
+        $("#price-range").slider({
+            range: true,
+            min: 0,
+            max: 1000000,
+            values: [min, max],
+            slide: function(event, ui) {
+                $("#minamount").val(ui.values[0]);
+                $("#maxamount").val(ui.values[1]);
+            }
+        });
+        $("#minamount").val($("#price-range").slider("values", 0));
+        $("#maxamount").val($("#price-range").slider("values", 1));
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ensure all theme home views reuse shared navigation and footer components
- restore full Restoran theme footer markup
- restructure Ogani product page with sidebar search, category, and price filters for a two-column layout
- add admin interface to manage product page settings

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c56971c6c48329b2d92122a7eca6e2