### PR TITLE
feat: add theme tags and preview

### DIFF
--- a/app/Http/Controllers/Admin/TagController.php
+++ b/app/Http/Controllers/Admin/TagController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Tag;
+use App\Models\Theme;
+use Illuminate\Http\Request;
+
+class TagController extends Controller
+{
+    public function index()
+    {
+        $tags = Tag::with('themes')->get();
+        return view('admin.tags.index', compact('tags'));
+    }
+
+    public function create()
+    {
+        $themes = Theme::all();
+        return view('admin.tags.create', compact('themes'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|unique:tags,name',
+            'themes' => 'array'
+        ]);
+        $tag = Tag::create(['name' => $data['name']]);
+        if (!empty($data['themes'])) {
+            $tag->themes()->attach($data['themes']);
+        }
+        return redirect()->route('admin.tags.index')->with('success', 'Tag created.');
+    }
+
+    public function edit(Tag $tag)
+    {
+        $themes = Theme::all();
+        $tag->load('themes');
+        return view('admin.tags.edit', compact('tag', 'themes'));
+    }
+
+    public function update(Request $request, Tag $tag)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|unique:tags,name,' . $tag->id,
+            'themes' => 'array'
+        ]);
+        $tag->update(['name' => $data['name']]);
+        $tag->themes()->sync($data['themes'] ?? []);
+        return redirect()->route('admin.tags.index')->with('success', 'Tag updated.');
+    }
+
+    public function destroy(Tag $tag)
+    {
+        $tag->delete();
+        return redirect()->route('admin.tags.index')->with('success', 'Tag deleted.');
+    }
+}

--- a/app/Http/Controllers/Admin/ThemeController.php
+++ b/app/Http/Controllers/Admin/ThemeController.php
@@ -4,16 +4,61 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\Setting;
+use App\Models\Theme;
+use App\Models\Tag;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
 
 class ThemeController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        $themes = array_map('basename', File::directories(base_path('themes')));
+        $dirs = array_map('basename', File::directories(base_path('themes')));
+        foreach ($dirs as $dir) {
+            $json = @json_decode(File::get(base_path("themes/{$dir}/theme.json")), true) ?: [];
+            $display = $json['displayName'] ?? ucfirst(substr($dir, 6));
+            Theme::updateOrCreate(
+                ['name' => $dir],
+                ['display_name' => $display]
+            );
+        }
+
+        $query = Theme::query()->with('tags');
+        if ($request->filled('tag')) {
+            $query->whereHas('tags', function ($q) use ($request) {
+                $q->where('tags.id', $request->tag);
+            });
+        }
+        $themes = $query->get();
+
+        $tags = Tag::all();
         $active = Setting::getValue('active_theme', 'theme-herbalgreen');
-        return view('admin.themes.index', compact('themes', 'active'));
+        $preview = route('admin.themes.preview', ['theme' => $active]);
+
+        return view('admin.themes.index', [
+            'themes' => $themes,
+            'active' => $active,
+            'tags' => $tags,
+            'preview' => $preview,
+            'selectedTag' => $request->tag
+        ]);
+    }
+
+    public function preview(string $theme)
+    {
+        $viewPath = base_path("themes/{$theme}/views/home.blade.php");
+        if (!File::exists($viewPath)) {
+            abort(404);
+        }
+
+        $source = base_path("themes/{$theme}/assets");
+        $destination = public_path("themes/{$theme}");
+        if (File::exists($source) && !File::exists($destination)) {
+            File::ensureDirectoryExists($destination);
+            File::copyDirectory($source, $destination);
+        }
+
+        return view()->file($viewPath, ['theme' => $theme]);
     }
 
     public function update(Request $request)

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function themes()
+    {
+        return $this->belongsToMany(Theme::class);
+    }
+}

--- a/app/Models/Theme.php
+++ b/app/Models/Theme.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Theme extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'display_name'];
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class);
+    }
+}

--- a/database/migrations/2025_09_12_000000_create_themes_table.php
+++ b/database/migrations/2025_09_12_000000_create_themes_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('themes', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('display_name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('themes');
+    }
+};

--- a/database/migrations/2025_09_12_000100_create_tags_table.php
+++ b/database/migrations/2025_09_12_000100_create_tags_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2025_09_12_000200_create_tag_theme_table.php
+++ b/database/migrations/2025_09_12_000200_create_tag_theme_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('tag_theme', function (Blueprint $table) {
+            $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('theme_id')->constrained()->cascadeOnDelete();
+            $table->primary(['tag_id', 'theme_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tag_theme');
+    }
+};

--- a/resources/views/admin/tags/create.blade.php
+++ b/resources/views/admin/tags/create.blade.php
@@ -1,0 +1,33 @@
+@extends('layout.admin')
+
+@section('content')
+  <div class="main-panel">
+    <div class="content-wrapper">
+      <div class="row">
+        <div class="col-12 grid-margin stretch-card">
+          <div class="card">
+            <div class="card-body">
+              <h4 class="card-title">Tambah Tag</h4>
+              <form method="POST" action="{{ route('admin.tags.store') }}">
+                @csrf
+                <div class="form-group">
+                  <label for="name">Nama</label>
+                  <input type="text" name="name" id="name" class="form-control" required>
+                </div>
+                <div class="form-group">
+                  <label for="themes">Theme</label>
+                  <select name="themes[]" id="themes" class="form-control" multiple>
+                    @foreach($themes as $theme)
+                      <option value="{{ $theme->id }}">{{ $theme->display_name }}</option>
+                    @endforeach
+                  </select>
+                </div>
+                <button type="submit" class="btn btn-primary">Simpan</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/admin/tags/edit.blade.php
+++ b/resources/views/admin/tags/edit.blade.php
@@ -1,0 +1,34 @@
+@extends('layout.admin')
+
+@section('content')
+  <div class="main-panel">
+    <div class="content-wrapper">
+      <div class="row">
+        <div class="col-12 grid-margin stretch-card">
+          <div class="card">
+            <div class="card-body">
+              <h4 class="card-title">Edit Tag</h4>
+              <form method="POST" action="{{ route('admin.tags.update', $tag) }}">
+                @csrf
+                @method('PUT')
+                <div class="form-group">
+                  <label for="name">Nama</label>
+                  <input type="text" name="name" id="name" class="form-control" value="{{ $tag->name }}" required>
+                </div>
+                <div class="form-group">
+                  <label for="themes">Theme</label>
+                  <select name="themes[]" id="themes" class="form-control" multiple>
+                    @foreach($themes as $theme)
+                      <option value="{{ $theme->id }}" {{ $tag->themes->contains($theme->id) ? 'selected' : '' }}>{{ $theme->display_name }}</option>
+                    @endforeach
+                  </select>
+                </div>
+                <button type="submit" class="btn btn-primary">Update</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/admin/tags/index.blade.php
+++ b/resources/views/admin/tags/index.blade.php
@@ -1,0 +1,48 @@
+@extends('layout.admin')
+
+@section('content')
+  <div class="main-panel">
+    <div class="content-wrapper">
+      <div class="row">
+        <div class="col-12 grid-margin stretch-card">
+          <div class="card">
+            <div class="card-body">
+              <h4 class="card-title">Tag</h4>
+              @if(session('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+              @endif
+              <a href="{{ route('admin.tags.create') }}" class="btn btn-primary mb-3">Tambah Tag</a>
+              <div class="table-responsive">
+                <table class="table">
+                  <thead>
+                    <tr>
+                      <th>Nama</th>
+                      <th>Theme</th>
+                      <th>Aksi</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @foreach($tags as $tag)
+                      <tr>
+                        <td>{{ $tag->name }}</td>
+                        <td>{{ $tag->themes->pluck('display_name')->join(', ') }}</td>
+                        <td>
+                          <a href="{{ route('admin.tags.edit', $tag) }}" class="btn btn-sm btn-warning">Edit</a>
+                          <form action="{{ route('admin.tags.destroy', $tag) }}" method="POST" style="display:inline-block" onsubmit="return confirm('Hapus tag?')">
+                            @csrf
+                            @method('DELETE')
+                            <button class="btn btn-sm btn-danger">Hapus</button>
+                          </form>
+                        </td>
+                      </tr>
+                    @endforeach
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/resources/views/admin/themes/index.blade.php
+++ b/resources/views/admin/themes/index.blade.php
@@ -11,17 +11,31 @@
               @if(session('success'))
                 <div class="alert alert-success">{{ session('success') }}</div>
               @endif
+
+              <form method="GET" action="{{ route('admin.themes.index') }}" class="mb-3">
+                <div class="form-group">
+                  <label for="tag_filter">Filter Tag</label>
+                  <select name="tag" id="tag_filter" class="form-control" onchange="this.form.submit()">
+                    <option value="">Semua</option>
+                    @foreach($tags as $tag)
+                      <option value="{{ $tag->id }}" {{ $selectedTag == $tag->id ? 'selected' : '' }}>{{ $tag->name }}</option>
+                    @endforeach
+                  </select>
+                </div>
+              </form>
+
               <form method="POST" action="{{ route('admin.themes.update') }}">
                 @csrf
                 <div class="form-group">
                   <label for="theme">Tema</label>
                   <select name="theme" id="theme" class="form-control">
                     @foreach($themes as $theme)
-                      <option value="{{ $theme }}" {{ $active === $theme ? 'selected' : '' }}>{{ ucfirst(substr($theme, 6)) }}</option>
+                      <option value="{{ $theme->name }}" data-preview="{{ route('admin.themes.preview', $theme->name) }}" {{ $active === $theme->name ? 'selected' : '' }}>{{ $theme->display_name }}</option>
                     @endforeach
                   </select>
                 </div>
-                <button type="submit" class="btn btn-primary">Simpan</button>
+                <iframe id="theme-preview" src="{{ $preview }}" class="w-100 mt-3" style="height:400px; border:1px solid #ddd;"></iframe>
+                <button type="submit" class="btn btn-primary mt-3">Simpan</button>
               </form>
             </div>
           </div>
@@ -29,5 +43,14 @@
       </div>
     </div>
   </div>
+@endsection
+
+@section('script')
+  <script>
+    document.getElementById('theme').addEventListener('change', function () {
+      const preview = this.options[this.selectedIndex].dataset.preview;
+      document.getElementById('theme-preview').src = preview;
+    });
+  </script>
 @endsection
 

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -89,6 +89,12 @@
               </a>
             </li>
             <li class="nav-item">
+              <a class="nav-link" href="{{url('/admin/tags')}}">
+                <i class="mdi mdi-tag-multiple menu-icon"></i>
+                <span class="menu-title">Tag Tema</span>
+              </a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link" data-toggle="collapse" href="#pages-menu" aria-expanded="false" aria-controls="pages-menu">
                 <i class="mdi mdi-arrange-bring-forward menu-icon"></i>
                 <span class="menu-title">Kelola Halaman</span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ThemeAssetController;
 use App\Http\Controllers\Admin\ThemeController;
+use App\Http\Controllers\Admin\TagController;
 use App\Http\Controllers\Admin\ProductController;
 use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\PageController;
@@ -78,6 +79,9 @@ Route::prefix('admin')/* ->middleware(['auth']) */->group(function () {
     // themes
     Route::get('themes', [ThemeController::class, 'index'])->name('admin.themes.index');
     Route::post('themes', [ThemeController::class, 'update'])->name('admin.themes.update');
+    Route::get('themes/preview/{theme}', [ThemeController::class, 'preview'])->name('admin.themes.preview');
+
+    Route::resource('tags', TagController::class)->except(['show'])->names('admin.tags');
 
     Route::get('pages/home', [PageController::class, 'home'])->name('admin.pages.home');
     Route::post('pages/home', [PageController::class, 'updateHome'])->name('admin.pages.home.update');


### PR DESCRIPTION
## Summary
- allow admins to manage theme tags with CRUD
- filter theme selection by tag and preview themes dynamically
- add database tables for themes and tags

## Testing
- `php -d detect_unicode=0 ./vendor/bin/phpunit` *(fails: Could not open input file: ./vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68c80e7cbeac83299fbd1d9e6baddd50