### PR TITLE
Add product detail pages and comment management

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -13,6 +13,25 @@ class Comment extends Model
     use HasFactory;
 
     /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'product_id',
+        'user_id',
+        'name',
+        'email',
+        'content',
+        'is_active',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     */
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    /**
      * Get the user that owns the Comment
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -7,6 +7,7 @@ use App\Models\Category;
 use App\Models\OrderItem;
 use App\Models\ProductImage;
 use App\Models\Brand;
+use App\Models\Comment;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -37,5 +38,9 @@ class Product extends Model
 
     public function orderItems(): HasMany {
         return $this->hasMany(OrderItem::class);
+    }
+
+    public function comments(): HasMany {
+        return $this->hasMany(Comment::class);
     }
 }

--- a/database/migrations/2025_09_05_135701_create_comments_table.php
+++ b/database/migrations/2025_09_05_135701_create_comments_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('name')->nullable();
+            $table->string('email')->nullable();
+            $table->text('content');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('comments');
+    }
+};

--- a/resources/views/admin/pages/product-detail.blade.php
+++ b/resources/views/admin/pages/product-detail.blade.php
@@ -1,0 +1,227 @@
+@extends('layout.admin')
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="row">
+      <div class="col-md-4" id="elements" style="max-height:100vh; overflow-y:auto;">
+        @foreach ($sections as $key => $section)
+        <div class="card mb-3" data-section="{{ $key }}">
+          <div class="card-header">{{ $section['label'] }}</div>
+          <div class="card-body">
+            @foreach ($section['elements'] as $element)
+              <div class="form-group">
+                @if ($element['type'] === 'checkbox')
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" data-key="{{ $element['id'] }}" {{ ($settings[$element['id']] ?? '1') == '1' ? 'checked' : '' }}>
+                    <label class="form-check-label">{{ $element['label'] }}</label>
+                  </div>
+                @elseif ($element['type'] === 'text')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="text" class="form-control" data-key="{{ $element['id'] }}" value="{{ $settings[$element['id']] ?? '' }}">
+                @elseif ($element['type'] === 'textarea')
+                  <label>{{ $element['label'] }}</label>
+                  <textarea class="form-control" data-key="{{ $element['id'] }}">{{ $settings[$element['id']] ?? '' }}</textarea>
+                @elseif ($element['type'] === 'image')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="file" class="form-control-file" data-key="{{ $element['id'] }}">
+                @elseif ($element['type'] === 'repeatable')
+                  @php
+                    $items = json_decode($settings[$element['id']] ?? '[]', true);
+                    $fields = $element['fields'] ?? [];
+                  @endphp
+                  <div data-repeatable="{{ $element['id'] }}" data-fields='@json($fields)'>
+                    <div class="repeatable-items"></div>
+                    <button type="button" class="btn btn-sm btn-secondary add-item">Add Item</button>
+                    <textarea class="d-none" data-key="{{ $element['id'] }}">{{ json_encode($items) }}</textarea>
+                  </div>
+                @else
+                  <p class="text-muted mb-0">{{ $element['label'] }}</p>
+                @endif
+              </div>
+            @endforeach
+          </div>
+        </div>
+        @endforeach
+      </div>
+      <div class="col-md-8 position-sticky" style="top:0;height:100vh">
+        @if($previewUrl)
+          <iframe id="page-preview" src="{{ $previewUrl }}" class="w-100 border h-100"></iframe>
+        @else
+          <div class="alert alert-info">Belum ada produk yang dapat ditampilkan. Tambahkan produk untuk melihat pratinjau.</div>
+        @endif
+      </div>
+    </div>
+
+    <div class="row mt-4">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <span>Kelola Komentar Produk</span>
+          </div>
+          <div class="card-body">
+            @if(session('success'))
+              <div class="alert alert-success">{{ session('success') }}</div>
+            @endif
+            @if($comments->isEmpty())
+              <p class="mb-0 text-muted">Belum ada komentar.</p>
+            @else
+              <div class="table-responsive">
+                <table class="table table-striped">
+                  <thead>
+                    <tr>
+                      <th>Produk</th>
+                      <th>Pengguna</th>
+                      <th>Komentar</th>
+                      <th>Tanggal</th>
+                      <th>Status</th>
+                      <th>Aksi</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @foreach($comments as $comment)
+                      <tr>
+                        <td>{{ $comment->product?->name ?? '-' }}</td>
+                        <td>{{ $comment->user?->name ?? $comment->name ?? 'Pengguna' }}</td>
+                        <td>{{ \Illuminate\Support\Str::limit($comment->content, 80) }}</td>
+                        <td>{{ optional($comment->created_at)->format('d M Y H:i') }}</td>
+                        <td>
+                          @if($comment->is_active)
+                            <span class="badge badge-success">Aktif</span>
+                          @else
+                            <span class="badge badge-secondary">Nonaktif</span>
+                          @endif
+                        </td>
+                        <td>
+                          <form method="POST" action="{{ route('admin.pages.product-detail.comments.toggle', $comment) }}">
+                            @csrf
+                            @method('PATCH')
+                            <button type="submit" class="btn btn-sm btn-outline-{{ $comment->is_active ? 'danger' : 'success' }}">
+                              {{ $comment->is_active ? 'Nonaktifkan' : 'Aktifkan' }}
+                            </button>
+                          </form>
+                        </td>
+                      </tr>
+                    @endforeach
+                  </tbody>
+                </table>
+              </div>
+            @endif
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+const csrf = '{{ csrf_token() }}';
+
+function reloadPreview() {
+  const iframe = document.getElementById('page-preview');
+  if (iframe) {
+    iframe.contentWindow.location.reload();
+  }
+}
+
+document.querySelectorAll('#elements [data-key]').forEach(function(input){
+  input.addEventListener('change', function(){
+    const key = this.getAttribute('data-key');
+    const formData = new FormData();
+    formData.append('key', key);
+    if(this.type === 'checkbox'){
+      formData.append('value', this.checked ? 1 : 0);
+    }else if(this.type === 'file'){
+      if(this.files[0]){ formData.append('value', this.files[0]); }
+    }else{
+      formData.append('value', this.value);
+    }
+    fetch('{{ route('admin.pages.product-detail.update') }}', {
+      method: 'POST',
+      headers: {'X-CSRF-TOKEN': csrf},
+      body: formData
+    }).then(() => {
+      reloadPreview();
+    });
+  });
+});
+
+document.querySelectorAll('[data-repeatable]').forEach(function(wrapper){
+  const itemsContainer = wrapper.querySelector('.repeatable-items');
+  const hidden = wrapper.querySelector('[data-key]');
+  const fields = JSON.parse(wrapper.getAttribute('data-fields') || '[]');
+
+  function buildItem(data = {}){
+    const div = document.createElement('div');
+    div.className = 'repeatable-item mb-2';
+    let html = '';
+    fields.forEach(function(field){
+      if((field.type || 'text') === 'textarea'){
+        html += `<textarea class="form-control mb-1" data-field="${field.name}" placeholder="${field.placeholder}">${data[field.name] || ''}</textarea>`;
+      }else{
+        html += `<input type="text" class="form-control mb-1" data-field="${field.name}" placeholder="${field.placeholder}" value="${data[field.name] || ''}">`;
+      }
+    });
+    html += '<button type="button" class="btn btn-sm btn-danger remove-item">Remove</button>';
+    div.innerHTML = html;
+    return div;
+  }
+
+  function sync(){
+    const data = [];
+    itemsContainer.querySelectorAll('.repeatable-item').forEach(function(item){
+      const obj = {};
+      item.querySelectorAll('[data-field]').forEach(function(input){
+        obj[input.getAttribute('data-field')] = input.value;
+      });
+      data.push(obj);
+    });
+    hidden.value = JSON.stringify(data);
+    hidden.dispatchEvent(new Event('change'));
+  }
+
+  wrapper.querySelector('.add-item').addEventListener('click', function(){
+    itemsContainer.appendChild(buildItem());
+  });
+
+  itemsContainer.addEventListener('input', sync);
+  itemsContainer.addEventListener('click', function(e){
+    if(e.target.classList.contains('remove-item')){
+      e.target.closest('.repeatable-item').remove();
+      sync();
+    }
+  });
+
+  try {
+    JSON.parse(hidden.value || '[]').forEach(function(item){
+      itemsContainer.appendChild(buildItem(item));
+    });
+  } catch(e) {}
+  sync();
+});
+
+document.querySelectorAll('#elements .card').forEach(function(card){
+  card.addEventListener('mouseenter', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    if(!iframe) return;
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '2px dashed #ff9800';
+      section.scrollIntoView({behavior:'smooth'});
+    }
+  });
+  card.addEventListener('mouseleave', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    if(!iframe) return;
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '';
+    }
+  });
+});
+</script>
+@endsection

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -104,6 +104,7 @@
                 <ul class="nav flex-column sub-menu">
                   <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/home')}}">Home</a></li>
                   <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/product')}}">Produk</a></li>
+                  <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/product-detail')}}">Detail Produk</a></li>
                 </ul>
               </div>
             </li>

--- a/themes/theme-herbalgreen/views/product-detail.blade.php
+++ b/themes/theme-herbalgreen/views/product-detail.blade.php
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Detail Produk</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+    <script src="{{ asset('themes/' . $theme . '/theme.js') }}" defer></script>
+    <style>
+        #product-detail .detail-grid { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); align-items: start; }
+        #product-detail .main-image { width: 100%; border-radius: 8px; overflow: hidden; }
+        #product-detail .main-image img { width: 100%; height: auto; display: block; }
+        #product-detail .thumbnail-slider { margin-top: 1rem; display: flex; gap: 0.75rem; flex-wrap: wrap; justify-content: center; }
+        #product-detail .thumbnail-slider img { width: 70px; height: 70px; object-fit: cover; border-radius: 6px; cursor: pointer; border: 2px solid transparent; transition: border 0.2s ease; }
+        #product-detail .thumbnail-slider img.active { border-color: var(--color-primary); }
+        #product-detail .product-info { text-align: left; }
+        #product-detail .price { font-size: 1.5rem; font-weight: 600; margin: 1rem 0; }
+        #product-detail .quantity-control { display: inline-flex; align-items: center; border: 1px solid var(--color-secondary); border-radius: 30px; overflow: hidden; }
+        #product-detail .quantity-control button { background: transparent; border: none; padding: 0.5rem 1rem; font-size: 1.1rem; cursor: pointer; }
+        #product-detail .quantity-control input { width: 60px; text-align: center; border: none; font-size: 1rem; }
+        #product-detail .description { margin-top: 1.5rem; line-height: 1.6; }
+        #comments { background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+        #comments .comment { padding: 1.5rem; border-bottom: 1px solid #e0f2f1; }
+        #comments .comment:last-child { border-bottom: none; }
+        #comments .comment strong { display: block; margin-bottom: 0.5rem; }
+        #recommendations .product-card .btn { margin-top: 1rem; display: inline-block; }
+    </style>
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Models\Product;
+
+    $settings = PageSetting::where('theme', $theme)->where('page', 'product-detail')->pluck('value', 'key')->toArray();
+
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+    ];
+
+    $footerLinks = [
+        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => ($settings['footer.privacy'] ?? '0') == '1'],
+        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => ($settings['footer.terms'] ?? '0') == '1'],
+    ];
+
+    $images = $product->images ?? collect();
+    $primaryImage = optional($images->first())->path;
+    $imageSources = $images->pluck('path')->filter()->map(fn($path) => asset('storage/'.$path))->values();
+    if ($imageSources->isEmpty()) {
+        $imageSources = collect(['https://via.placeholder.com/600x400?text=No+Image']);
+        $primaryImage = null;
+    }
+
+    $comments = $product->comments ?? collect();
+
+    $recommendationsQuery = Product::query()->where('id', '!=', $product->id);
+    if ($product->categories && $product->categories->count()) {
+        $recommendationsQuery->whereHas('categories', fn($q) => $q->whereIn('categories.id', $product->categories->pluck('id')));
+    }
+    $recommendations = $recommendationsQuery->with('images')->take(5)->get();
+    if ($recommendations->count() < 5) {
+        $fallback = Product::where('id', '!=', $product->id)
+            ->whereNotIn('id', $recommendations->pluck('id'))
+            ->with('images')
+            ->take(5 - $recommendations->count())
+            ->get();
+        $recommendations = $recommendations->concat($fallback);
+    }
+@endphp
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+
+@if(($settings['hero.visible'] ?? '1') == '1')
+<section id="hero" class="hero" @if(!empty($settings['hero.image'])) style="background-image:url('{{ asset('storage/'.$settings['hero.image']) }}')" @endif>
+    <div class="hero-content">
+        <h1>{{ $settings['hero.title'] ?? $product->name }}</h1>
+        <p>{{ $product->short_description ?? 'Temukan detail lengkap produk pilihan Anda.' }}</p>
+    </div>
+</section>
+@endif
+
+<section id="product-detail" class="products">
+    <h2>{{ $product->name }}</h2>
+    <div class="product-grid detail-grid">
+        <div class="product-card">
+            <div class="main-image">
+                @php $mainImageUrl = $primaryImage ? asset('storage/'.$primaryImage) : $imageSources->first(); @endphp
+                <img src="{{ $mainImageUrl }}" alt="{{ $product->name }}" id="mainProductImage">
+            </div>
+            <div class="thumbnail-slider">
+                @foreach($imageSources as $index => $src)
+                    <img src="{{ $src }}" data-full="{{ $src }}" class="thumbnail {{ $index === 0 ? 'active' : '' }}" alt="{{ $product->name }} thumbnail {{ $index + 1 }}">
+                @endforeach
+            </div>
+        </div>
+        <div class="product-card product-info">
+            <h3>{{ $product->name }}</h3>
+            <p class="price">Rp {{ number_format($product->price, 0, ',', '.') }}</p>
+            <div class="quantity-control" id="quantityControl">
+                <button type="button" data-action="decrease">-</button>
+                <input type="number" value="1" min="1" id="quantityInput">
+                <button type="button" data-action="increase">+</button>
+            </div>
+            <button class="cta" id="addToCartButton">Masukkan ke Keranjang</button>
+            <div class="description">
+                {!! $product->description ? nl2br(e($product->description)) : '<p>Belum ada deskripsi produk.</p>' !!}
+            </div>
+        </div>
+    </div>
+</section>
+
+@if(($settings['comments.visible'] ?? '1') == '1')
+<section id="comments" class="section">
+    <h2>{{ $settings['comments.heading'] ?? 'Komentar Produk' }}</h2>
+    @if($comments->isEmpty())
+        <p class="text-center">Belum ada komentar.</p>
+    @else
+        @foreach($comments as $comment)
+            <div class="comment">
+                <strong>{{ $comment->user?->name ?? $comment->name ?? 'Pengguna' }}</strong>
+                <small>{{ optional($comment->created_at)->format('d M Y') }}</small>
+                <p>{{ $comment->content }}</p>
+            </div>
+        @endforeach
+    @endif
+</section>
+@endif
+
+@if(($settings['recommendations.visible'] ?? '1') == '1' && $recommendations->count())
+<section id="recommendations" class="products">
+    <h2>{{ $settings['recommendations.heading'] ?? 'Produk Serupa' }}</h2>
+    <div class="product-grid">
+        @foreach($recommendations as $item)
+            @php $img = optional($item->images->first())->path; @endphp
+            <div class="product-card">
+                <img src="{{ $img ? asset('storage/'.$img) : 'https://via.placeholder.com/150' }}" alt="{{ $item->name }}">
+                <h3>{{ $item->name }}</h3>
+                <p>{{ $item->price_formatted ?? number_format($item->price,0,',','.') }}</p>
+                <a href="{{ route('products.show', $item) }}" class="btn">Detail</a>
+            </div>
+        @endforeach
+    </div>
+</section>
+@endif
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
+    'links' => $footerLinks,
+    'copyright' => $settings['footer.copyright'] ?? ('© '.date('Y') . ' Herbal Green')
+])->render() !!}
+
+<script>
+    document.addEventListener('DOMContentLoaded', function(){
+        const thumbnails = document.querySelectorAll('#product-detail .thumbnail-slider img');
+        const mainImage = document.getElementById('mainProductImage');
+        thumbnails.forEach(function(thumb){
+            thumb.addEventListener('click', function(){
+                thumbnails.forEach(t => t.classList.remove('active'));
+                this.classList.add('active');
+                const full = this.getAttribute('data-full');
+                if(full){
+                    mainImage.src = full;
+                }
+            });
+        });
+
+        const control = document.getElementById('quantityControl');
+        const input = document.getElementById('quantityInput');
+        if(control && input){
+            control.addEventListener('click', function(event){
+                const button = event.target.closest('button[data-action]');
+                if(!button) return;
+                const action = button.getAttribute('data-action');
+                let current = parseInt(input.value || '1', 10);
+                if(action === 'increase') current += 1;
+                if(action === 'decrease') current = Math.max(1, current - 1);
+                input.value = current;
+            });
+        }
+
+        const addToCart = document.getElementById('addToCartButton');
+        if(addToCart){
+            addToCart.addEventListener('click', function(){
+                alert('Produk ditambahkan ke keranjang (' + (document.getElementById('quantityInput')?.value || 1) + ' pcs).');
+            });
+        }
+    });
+</script>
+</body>
+</html>

--- a/themes/theme-herbalgreen/views/product.blade.php
+++ b/themes/theme-herbalgreen/views/product.blade.php
@@ -62,7 +62,7 @@
                 <img src="{{ $img ? asset('storage/'.$img) : 'https://via.placeholder.com/150' }}" alt="{{ $product->name }}">
                 <h3>{{ $product->name }}</h3>
                 <p>{{ $product->price_formatted ?? number_format($product->price,0,',','.') }}</p>
-                <a href="{{ url('products/'.$product->id) }}" class="btn">Detail</a>
+                <a href="{{ route('products.show', $product) }}" class="btn">Detail</a>
             </div>
         @endforeach
     </div>

--- a/themes/theme-restoran/views/product-detail.blade.php
+++ b/themes/theme-restoran/views/product-detail.blade.php
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Detail Produk</title>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <link href="{{ asset('storage/themes/theme-restoran/img/favicon.ico') }}" rel="icon">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600&family=Nunito:wght@600;700;800&family=Pacifico&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.0/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/animate/animate.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/assets/owl.carousel.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/css/tempusdominus-bootstrap-4.min.css') }}" rel="stylesheet" />
+    <link href="{{ asset('storage/themes/theme-restoran/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/css/style.css') }}" rel="stylesheet">
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Models\Product;
+
+    $settings = PageSetting::where('theme', 'theme-restoran')->where('page', 'product-detail')->pluck('value','key')->toArray();
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+    ];
+
+    $images = $product->images ?? collect();
+    $imageSources = $images->pluck('path')->filter()->map(fn($path) => asset('storage/'.$path))->values();
+    if ($imageSources->isEmpty()) {
+        $imageSources = collect(['https://via.placeholder.com/600x400?text=No+Image']);
+    }
+
+    $comments = $product->comments ?? collect();
+
+    $recommendationsQuery = Product::query()->where('id', '!=', $product->id);
+    if ($product->categories && $product->categories->count()) {
+        $recommendationsQuery->whereHas('categories', fn($q) => $q->whereIn('categories.id', $product->categories->pluck('id')));
+    }
+    $recommendations = $recommendationsQuery->with('images')->take(5)->get();
+    if ($recommendations->count() < 5) {
+        $fallback = Product::where('id', '!=', $product->id)
+            ->whereNotIn('id', $recommendations->pluck('id'))
+            ->with('images')
+            ->take(5 - $recommendations->count())
+            ->get();
+        $recommendations = $recommendations->concat($fallback);
+    }
+@endphp
+<div class="container-xxl position-relative p-0">
+    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+    @if(($settings['hero.visible'] ?? '1') == '1')
+    <div class="container-xxl py-5 bg-dark hero-header mb-5" @if(!empty($settings['hero.image'])) style="background-image:url('{{ asset('storage/'.$settings['hero.image']) }}'); background-size:cover; background-position:center;" @endif>
+        <div class="container text-center my-5 pt-5 pb-4">
+            <h1 class="display-3 text-white mb-3">{{ $settings['hero.title'] ?? $product->name }}</h1>
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb justify-content-center text-uppercase">
+                    <li class="breadcrumb-item"><a href="{{ url('/') }}">Home</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url('/produk') }}">Produk</a></li>
+                    <li class="breadcrumb-item text-white active" aria-current="page">{{ $product->name }}</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+    @endif
+</div>
+
+<div class="container py-5">
+    <div class="row g-5 align-items-start">
+        <div class="col-lg-6">
+            <div class="position-relative overflow-hidden rounded">
+                <img src="{{ $imageSources->first() }}" alt="{{ $product->name }}" class="img-fluid w-100" id="mainProductImage">
+            </div>
+            <div class="d-flex flex-wrap gap-2 mt-3">
+                @foreach($imageSources as $index => $src)
+                    <img src="{{ $src }}" data-full="{{ $src }}" class="img-thumbnail product-thumb {{ $index === 0 ? 'border-primary' : '' }}" style="width: 80px; height: 80px; object-fit: cover; cursor:pointer;" alt="{{ $product->name }} thumbnail {{ $index + 1 }}">
+                @endforeach
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <h2 class="mb-3">{{ $product->name }}</h2>
+            <h3 class="text-primary mb-4">Rp {{ number_format($product->price, 0, ',', '.') }}</h3>
+            <p class="mb-4">{{ $product->short_description ?? 'Nikmati cita rasa terbaik dari produk pilihan kami.' }}</p>
+            <div class="d-flex align-items-center mb-3" id="quantityControl">
+                <div class="input-group" style="width: 150px;">
+                    <button class="btn btn-outline-secondary" type="button" data-action="decrease">-</button>
+                    <input type="number" class="form-control text-center" value="1" min="1" id="quantityInput">
+                    <button class="btn btn-outline-secondary" type="button" data-action="increase">+</button>
+                </div>
+            </div>
+            <div class="mb-4">
+                <button class="btn btn-primary py-2 px-4 me-2" id="addToCartButton"><i class="bi bi-cart"></i> Masukkan ke Keranjang</button>
+                <button class="btn btn-outline-primary py-2 px-4"><i class="bi bi-heart"></i></button>
+            </div>
+            <div class="mt-4">
+                <h5 class="mb-3">Deskripsi Produk</h5>
+                <p>{!! $product->description ? nl2br(e($product->description)) : 'Belum ada deskripsi produk.' !!}</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if(($settings['comments.visible'] ?? '1') == '1')
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <h3 class="mb-4 text-center">{{ $settings['comments.heading'] ?? 'Komentar Pelanggan' }}</h3>
+            @if($comments->isEmpty())
+                <p class="text-center text-muted">Belum ada komentar untuk produk ini.</p>
+            @else
+                @foreach($comments as $comment)
+                    <div class="card border-0 shadow-sm mb-3">
+                        <div class="card-body">
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <h5 class="card-title mb-0">{{ $comment->user?->name ?? $comment->name ?? 'Pengguna' }}</h5>
+                                <small class="text-muted">{{ optional($comment->created_at)->format('d M Y') }}</small>
+                            </div>
+                            <p class="card-text mb-0">{{ $comment->content }}</p>
+                        </div>
+                    </div>
+                @endforeach
+            @endif
+        </div>
+    </div>
+</div>
+@endif
+
+@if(($settings['recommendations.visible'] ?? '1') == '1' && $recommendations->count())
+<div class="container py-5">
+    <div class="text-center mb-5">
+        <h2 class="section-title ff-secondary text-center text-primary fw-normal">{{ $settings['recommendations.heading'] ?? 'Produk Serupa' }}</h2>
+    </div>
+    <div class="row g-4">
+        @foreach($recommendations as $item)
+            @php $img = optional($item->images->first())->path; @endphp
+            <div class="col-lg-6">
+                <div class="d-flex align-items-center">
+                    <img class="flex-shrink-0 img-fluid rounded" src="{{ $img ? asset('storage/'.$img) : asset('storage/themes/theme-restoran/img/menu-1.jpg') }}" alt="{{ $item->name }}" style="width: 80px;">
+                    <div class="w-100 d-flex flex-column text-start ps-4">
+                        <h5 class="d-flex justify-content-between border-bottom pb-2">
+                            <span>{{ $item->name }}</span>
+                            <span class="text-primary">{{ $item->price_formatted ?? number_format($item->price,0,',','.') }}</span>
+                        </h5>
+                        <small class="fst-italic">{{ \Illuminate\Support\Str::limit($item->short_description ?? $item->description, 80) }}</small>
+                        <a href="{{ route('products.show', $item) }}" class="btn btn-sm btn-primary mt-2 align-self-start">Detail</a>
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+</div>
+@endif
+
+{!! view()->file(base_path('themes/theme-restoran/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+
+<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/wow/wow.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/easing/easing.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/waypoints/waypoints.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/counterup/counterup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment-timezone.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/tempusdominus-bootstrap-4.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/js/main.js') }}"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function(){
+        const thumbs = document.querySelectorAll('.product-thumb');
+        const mainImage = document.getElementById('mainProductImage');
+        thumbs.forEach(function(thumb){
+            thumb.addEventListener('click', function(){
+                thumbs.forEach(t => t.classList.remove('border-primary'));
+                this.classList.add('border-primary');
+                const full = this.getAttribute('data-full');
+                if(full){
+                    mainImage.src = full;
+                }
+            });
+        });
+
+        const control = document.getElementById('quantityControl');
+        const input = document.getElementById('quantityInput');
+        if(control && input){
+            control.addEventListener('click', function(event){
+                const button = event.target.closest('button[data-action]');
+                if(!button) return;
+                const action = button.getAttribute('data-action');
+                let current = parseInt(input.value || '1', 10);
+                if(action === 'increase') current += 1;
+                if(action === 'decrease') current = Math.max(1, current - 1);
+                input.value = current;
+            });
+        }
+
+        const addToCart = document.getElementById('addToCartButton');
+        if(addToCart){
+            addToCart.addEventListener('click', function(){
+                alert('Produk ditambahkan ke keranjang sebanyak ' + (document.getElementById('quantityInput')?.value || 1) + ' pcs.');
+            });
+        }
+    });
+</script>
+</body>
+</html>

--- a/themes/theme-restoran/views/product.blade.php
+++ b/themes/theme-restoran/views/product.blade.php
@@ -88,7 +88,7 @@
                         <span class="text-primary">{{ $product->price_formatted ?? number_format($product->price,0,',','.') }}</span>
                     </h5>
                     <small class="fst-italic">{{ $product->description }}</small>
-                    <a href="{{ url('products/'.$product->id) }}" class="btn btn-sm btn-primary mt-2 align-self-start">Detail</a>
+                    <a href="{{ route('products.show', $product) }}" class="btn btn-sm btn-primary mt-2 align-self-start">Detail</a>
                 </div>
             </div>
         </div>

--- a/themes/theme-second/views/product-detail.blade.php
+++ b/themes/theme-second/views/product-detail.blade.php
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Detail Produk</title>
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/bootstrap.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/font-awesome.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/elegant-icons.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/nice-select.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/jquery-ui.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/owl.carousel.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/slicknav.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/style.css') }}" type="text/css">
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Models\Product;
+
+    $settings = PageSetting::where('theme', 'theme-second')->where('page', 'product-detail')->pluck('value', 'key')->toArray();
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+    ];
+
+    $images = $product->images ?? collect();
+    $imageSources = $images->pluck('path')->filter()->map(fn($path) => asset('storage/'.$path))->values();
+    if ($imageSources->isEmpty()) {
+        $imageSources = collect(['https://via.placeholder.com/600x400?text=No+Image']);
+    }
+
+    $comments = $product->comments ?? collect();
+
+    $recommendationsQuery = Product::query()->where('id', '!=', $product->id);
+    if ($product->categories && $product->categories->count()) {
+        $recommendationsQuery->whereHas('categories', fn($q) => $q->whereIn('categories.id', $product->categories->pluck('id')));
+    }
+    $recommendations = $recommendationsQuery->with('images')->take(5)->get();
+    if ($recommendations->count() < 5) {
+        $fallback = Product::where('id', '!=', $product->id)
+            ->whereNotIn('id', $recommendations->pluck('id'))
+            ->with('images')
+            ->take(5 - $recommendations->count())
+            ->get();
+        $recommendations = $recommendations->concat($fallback);
+    }
+@endphp
+{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+
+<section class="breadcrumb-section set-bg" data-setbg="{{ !empty($settings['hero.image']) ? asset('storage/'.$settings['hero.image']) : asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <div class="breadcrumb__text">
+                    <h2>{{ $settings['hero.title'] ?? $product->name }}</h2>
+                    <div class="breadcrumb__option">
+                        <a href="{{ url('/') }}">Home</a>
+                        <a href="{{ url('/produk') }}">Produk</a>
+                        <span>{{ $product->name }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="product-details spad">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-6 col-md-6">
+                <div class="product__details__pic">
+                    <div class="product__details__pic__item">
+                        <img class="product__details__pic__item--large" src="{{ $imageSources->first() }}" alt="{{ $product->name }}" id="mainProductImage">
+                    </div>
+                    <div class="product__details__pic__slider owl-carousel">
+                        @foreach($imageSources as $src)
+                            <img data-imgbigurl="{{ $src }}" src="{{ $src }}" alt="{{ $product->name }} thumbnail">
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-6 col-md-6">
+                <div class="product__details__text">
+                    <h3>{{ $product->name }}</h3>
+                    <div class="product__details__price">Rp {{ number_format($product->price, 0, ',', '.') }}</div>
+                    <p>{{ $product->short_description ?? 'Produk pilihan terbaik untuk memenuhi kebutuhan Anda setiap hari.' }}</p>
+                    <div class="product__details__quantity">
+                        <div class="quantity">
+                            <div class="pro-qty">
+                                <input type="text" value="1" id="quantityInput">
+                            </div>
+                        </div>
+                    </div>
+                    <a href="#" class="primary-btn" id="addToCartButton">MASUKKAN KE KERANJANG</a>
+                    <a href="#" class="heart-icon"><span class="icon_heart_alt"></span></a>
+                    <ul>
+                        <li><b>Ketersediaan</b> <span>{{ $product->stock > 0 ? 'Stok Tersedia' : 'Stok Habis' }}</span></li>
+                        <li><b>Berat</b> <span>{{ $product->weight ? $product->weight.' kg' : '-' }}</span></li>
+                        <li><b>Bagikan</b>
+                            <div class="share">
+                                <a href="#"><i class="fa fa-facebook"></i></a>
+                                <a href="#"><i class="fa fa-twitter"></i></a>
+                                <a href="#"><i class="fa fa-instagram"></i></a>
+                                <a href="#"><i class="fa fa-pinterest"></i></a>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="col-lg-12">
+                <div class="product__details__tab">
+                    <ul class="nav nav-tabs" role="tablist">
+                        <li class="nav-item">
+                            <a class="nav-link active" data-toggle="tab" href="#tabs-1" role="tab" aria-selected="true">Deskripsi</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" data-toggle="tab" href="#tabs-2" role="tab" aria-selected="false">Informasi</a>
+                        </li>
+                        @if(($settings['comments.visible'] ?? '1') == '1')
+                        <li class="nav-item">
+                            <a class="nav-link" data-toggle="tab" href="#tabs-3" role="tab" aria-selected="false">Komentar <span>({{ $comments->count() }})</span></a>
+                        </li>
+                        @endif
+                    </ul>
+                    <div class="tab-content">
+                        <div class="tab-pane active" id="tabs-1" role="tabpanel">
+                            <div class="product__details__tab__desc">
+                                {!! $product->description ? nl2br(e($product->description)) : '<p>Belum ada deskripsi produk.</p>' !!}
+                            </div>
+                        </div>
+                        <div class="tab-pane" id="tabs-2" role="tabpanel">
+                            <div class="product__details__tab__desc">
+                                <ul class="list-unstyled">
+                                    <li><strong>Kategori:</strong> {{ $product->categories->pluck('name')->join(', ') ?: '-' }}</li>
+                                    <li><strong>Merek:</strong> {{ $product->brand?->name ?? '-' }}</li>
+                                    <li><strong>SKU:</strong> {{ $product->sku ?? '-' }}</li>
+                                    <li><strong>Dimensi:</strong> {{ $product->length }} x {{ $product->width }} x {{ $product->height }}</li>
+                                </ul>
+                            </div>
+                        </div>
+                        @if(($settings['comments.visible'] ?? '1') == '1')
+                        <div class="tab-pane" id="tabs-3" role="tabpanel">
+                            <div class="product__details__tab__desc">
+                                @if($comments->isEmpty())
+                                    <p>Belum ada komentar.</p>
+                                @else
+                                    @foreach($comments as $comment)
+                                        <div class="mb-4">
+                                            <h6 class="mb-1">{{ $comment->user?->name ?? $comment->name ?? 'Pengguna' }}</h6>
+                                            <small class="text-muted d-block mb-2">{{ optional($comment->created_at)->format('d M Y') }}</small>
+                                            <p class="mb-0">{{ $comment->content }}</p>
+                                        </div>
+                                    @endforeach
+                                @endif
+                            </div>
+                        </div>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+@if(($settings['recommendations.visible'] ?? '1') == '1' && $recommendations->count())
+<section class="related-product">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="section-title related__product__title">
+                    <h2>{{ $settings['recommendations.heading'] ?? 'Produk Serupa' }}</h2>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            @foreach($recommendations as $item)
+                @php $img = optional($item->images->first())->path; @endphp
+                <div class="col-lg-3 col-md-4 col-sm-6">
+                    <div class="product__item">
+                        <div class="product__item__pic set-bg" data-setbg="{{ $img ? asset('storage/'.$img) : asset('storage/themes/theme-second/img/product/product-1.jpg') }}">
+                            <ul class="product__item__pic__hover">
+                                <li><a href="#"><i class="fa fa-heart"></i></a></li>
+                                <li><a href="#"><i class="fa fa-retweet"></i></a></li>
+                                <li><a href="#"><i class="fa fa-shopping-cart"></i></a></li>
+                            </ul>
+                        </div>
+                        <div class="product__item__text">
+                            <h6><a href="{{ route('products.show', $item) }}">{{ $item->name }}</a></h6>
+                            <h5>{{ $item->price_formatted ?? number_format($item->price,0,',','.') }}</h5>
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+</section>
+@endif
+
+{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+
+<script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.nice-select.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery-ui.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.slicknav.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/mixitup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/main.js') }}"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function(){
+        const addToCart = document.getElementById('addToCartButton');
+        if(addToCart){
+            addToCart.addEventListener('click', function(event){
+                event.preventDefault();
+                alert('Produk ditambahkan ke keranjang sebanyak ' + (document.getElementById('quantityInput')?.value || 1) + ' pcs.');
+            });
+        }
+    });
+</script>
+</body>
+</html>

--- a/themes/theme-second/views/product.blade.php
+++ b/themes/theme-second/views/product.blade.php
@@ -142,7 +142,7 @@
                                     </ul>
                                 </div>
                                 <div class="product__item__text">
-                                    <h6><a href="{{ url('products/'.$product->id) }}">{{ $product->name }}</a></h6>
+                                    <h6><a href="{{ route('products.show', $product) }}">{{ $product->name }}</a></h6>
                                     <h5>{{ $product->price_formatted ?? number_format($product->price,0,',','.') }}</h5>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- introduce a comments table and update the product/comment models to support moderation from the admin area
- add product-detail page management in the admin UI, including preview and comment activation controls, plus routing updates
- implement product detail pages for each theme with galleries, quantity controls, and related products while updating product listings to link to the new detail view

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c95b05d7008329a1219ef83e8e758b