### PR TITLE
Implement cart functionality across themes

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -238,6 +238,70 @@ class PageController extends Controller
         return response()->json(['status' => 'ok']);
     }
 
+    public function cart()
+    {
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+        $settings = PageSetting::where('theme', $theme)->where('page', 'cart')->pluck('value', 'key');
+
+        $sections = [
+            'header' => [
+                'label' => 'Header',
+                'elements' => [
+                    ['type' => 'text', 'label' => 'Judul Halaman', 'id' => 'title'],
+                    ['type' => 'textarea', 'label' => 'Deskripsi Singkat', 'id' => 'subtitle'],
+                ],
+            ],
+            'empty' => [
+                'label' => 'Keranjang Kosong',
+                'elements' => [
+                    ['type' => 'textarea', 'label' => 'Pesan Keranjang Kosong', 'id' => 'empty.message'],
+                    ['type' => 'text', 'label' => 'Label Tombol Belanja', 'id' => 'empty.button'],
+                ],
+            ],
+            'actions' => [
+                'label' => 'Tombol Aksi',
+                'elements' => [
+                    ['type' => 'text', 'label' => 'Label Tombol Pengiriman', 'id' => 'button.shipping'],
+                    ['type' => 'text', 'label' => 'Label Tombol Pembayaran', 'id' => 'button.payment'],
+                ],
+            ],
+            'footer' => [
+                'label' => 'Footer',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Privacy Policy link', 'id' => 'footer.privacy'],
+                    ['type' => 'checkbox', 'label' => 'Terms & Conditions link', 'id' => 'footer.terms'],
+                    ['type' => 'text', 'label' => 'Copyright Text', 'id' => 'footer.copyright'],
+                ],
+            ],
+        ];
+
+        $previewUrl = route('cart.index');
+
+        return view('admin.pages.cart', compact('sections', 'settings', 'previewUrl'));
+    }
+
+    public function updateCart(Request $request)
+    {
+        $request->validate([
+            'key' => 'required',
+            'value' => 'nullable',
+        ]);
+
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+
+        $value = $request->input('value');
+        if ($request->hasFile('value')) {
+            $value = $request->file('value')->store("pages/{$theme}", 'public');
+        }
+
+        PageSetting::updateOrCreate(
+            ['theme' => $theme, 'page' => 'cart', 'key' => $request->input('key')],
+            ['value' => $value]
+        );
+
+        return response()->json(['status' => 'ok']);
+    }
+
     public function toggleComment(Comment $comment)
     {
         $comment->is_active = ! $comment->is_active;

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use App\Models\Setting;
+use App\Models\PageSetting;
+use App\Support\Cart;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
+
+class CartController extends Controller
+{
+    public function index()
+    {
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+        $settings = PageSetting::where('theme', $theme)
+            ->where('page', 'cart')
+            ->pluck('value', 'key')
+            ->toArray();
+
+        $viewPath = base_path("themes/{$theme}/views/cart.blade.php");
+        if (! File::exists($viewPath)) {
+            abort(404);
+        }
+
+        $cart = Cart::summary();
+        $shippingEnabled = Setting::getValue('shipping.enabled', '0') === '1';
+        $biteshipActive = Setting::getValue('shipping.provider', '') === 'biteship';
+
+        return view()->file($viewPath, [
+            'theme' => $theme,
+            'settings' => $settings,
+            'cartSummary' => $cart,
+            'shippingEnabled' => $shippingEnabled && $biteshipActive,
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'product_id' => ['required', 'exists:products,id'],
+            'quantity' => ['nullable', 'integer', 'min:1'],
+        ]);
+
+        $product = Product::with('images')->findOrFail($data['product_id']);
+        $quantity = $data['quantity'] ?? 1;
+
+        Cart::add($product, $quantity);
+
+        $summary = Cart::summary();
+
+        return response()->json([
+            'status' => 'ok',
+            'message' => 'Produk ditambahkan ke keranjang.',
+            'summary' => $summary,
+        ], 201);
+    }
+
+    public function update(Request $request, Product $product): JsonResponse
+    {
+        $data = $request->validate([
+            'quantity' => ['required', 'integer', 'min:0'],
+        ]);
+
+        Cart::updateQuantity($product->getKey(), (int) $data['quantity']);
+
+        $summary = Cart::summary();
+
+        return response()->json([
+            'status' => 'ok',
+            'summary' => $summary,
+        ]);
+    }
+
+    public function destroy(Product $product): JsonResponse
+    {
+        Cart::remove($product->getKey());
+
+        $summary = Cart::summary();
+
+        return response()->json([
+            'status' => 'ok',
+            'summary' => $summary,
+        ]);
+    }
+}
+

--- a/app/Support/Cart.php
+++ b/app/Support/Cart.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Product;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Session;
+
+class Cart
+{
+    protected const SESSION_KEY = 'cart.items';
+
+    public static function items(): array
+    {
+        return Session::get(self::SESSION_KEY, []);
+    }
+
+    protected static function storeItems(array $items): void
+    {
+        Session::put(self::SESSION_KEY, $items);
+    }
+
+    public static function add(Product $product, int $quantity = 1): array
+    {
+        $quantity = max(1, $quantity);
+        $items = self::items();
+        $productId = (int) $product->getKey();
+
+        if (isset($items[$productId])) {
+            $items[$productId]['quantity'] += $quantity;
+        } else {
+            $items[$productId] = [
+                'product_id' => $productId,
+                'name' => $product->name,
+                'slug' => $product->slug,
+                'price' => (int) $product->price,
+                'quantity' => $quantity,
+                'image' => optional($product->images()->first())->path,
+            ];
+        }
+
+        self::storeItems($items);
+
+        return $items[$productId];
+    }
+
+    public static function updateQuantity(int $productId, int $quantity): ?array
+    {
+        $items = self::items();
+        $productId = (int) $productId;
+
+        if (! isset($items[$productId])) {
+            return null;
+        }
+
+        if ($quantity <= 0) {
+            unset($items[$productId]);
+            self::storeItems($items);
+            return null;
+        }
+
+        $items[$productId]['quantity'] = $quantity;
+        self::storeItems($items);
+
+        return $items[$productId];
+    }
+
+    public static function remove(int $productId): void
+    {
+        $items = self::items();
+        unset($items[(int) $productId]);
+        self::storeItems($items);
+    }
+
+    public static function clear(): void
+    {
+        Session::forget(self::SESSION_KEY);
+    }
+
+    public static function totalQuantity(): int
+    {
+        return array_sum(Arr::pluck(self::items(), 'quantity'));
+    }
+
+    public static function totalPrice(): int
+    {
+        return array_sum(array_map(function ($item) {
+            return (int) $item['price'] * (int) $item['quantity'];
+        }, self::items()));
+    }
+
+    public static function summary(): array
+    {
+        $items = collect(self::items())
+            ->map(function ($item) {
+                $item['price'] = (int) $item['price'];
+                $item['quantity'] = (int) $item['quantity'];
+                $item['subtotal'] = $item['price'] * $item['quantity'];
+                $item['price_formatted'] = number_format($item['price'], 0, ',', '.');
+                $item['subtotal_formatted'] = number_format($item['subtotal'], 0, ',', '.');
+                $item['image_url'] = $item['image'] ? asset('storage/' . $item['image']) : 'https://via.placeholder.com/120x120?text=No+Image';
+                $item['product_url'] = route('products.show', $item['product_id']);
+
+                return $item;
+            })
+            ->values()
+            ->toArray();
+
+        $totalPrice = self::totalPrice();
+
+        return [
+            'items' => $items,
+            'total_quantity' => self::totalQuantity(),
+            'total_price' => $totalPrice,
+            'total_price_formatted' => number_format($totalPrice, 0, ',', '.'),
+        ];
+    }
+}
+

--- a/resources/views/admin/pages/cart.blade.php
+++ b/resources/views/admin/pages/cart.blade.php
@@ -1,0 +1,160 @@
+@extends('layout.admin')
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="row">
+      <div class="col-md-4" id="elements" style="max-height:100vh; overflow-y:auto;">
+        @foreach ($sections as $key => $section)
+          <div class="card mb-3" data-section="{{ $key }}">
+            <div class="card-header">{{ $section['label'] }}</div>
+            <div class="card-body">
+              @foreach ($section['elements'] as $element)
+                <div class="form-group">
+                  @if ($element['type'] === 'checkbox')
+                    <div class="form-check">
+                      <input class="form-check-input" type="checkbox" data-key="{{ $element['id'] }}" {{ ($settings[$element['id']] ?? '1') == '1' ? 'checked' : '' }}>
+                      <label class="form-check-label">{{ $element['label'] }}</label>
+                    </div>
+                  @elseif ($element['type'] === 'text')
+                    <label>{{ $element['label'] }}</label>
+                    <input type="text" class="form-control" data-key="{{ $element['id'] }}" value="{{ $settings[$element['id']] ?? '' }}">
+                  @elseif ($element['type'] === 'textarea')
+                    <label>{{ $element['label'] }}</label>
+                    <textarea class="form-control" data-key="{{ $element['id'] }}">{{ $settings[$element['id']] ?? '' }}</textarea>
+                  @elseif ($element['type'] === 'image')
+                    <label>{{ $element['label'] }}</label>
+                    <input type="file" class="form-control-file" data-key="{{ $element['id'] }}">
+                  @elseif ($element['type'] === 'repeatable')
+                    @php
+                      $items = json_decode($settings[$element['id']] ?? '[]', true);
+                      $fields = $element['fields'] ?? [];
+                    @endphp
+                    <div data-repeatable="{{ $element['id'] }}" data-fields='@json($fields)'>
+                      <div class="repeatable-items"></div>
+                      <button type="button" class="btn btn-sm btn-secondary add-item">Add Item</button>
+                      <textarea class="d-none" data-key="{{ $element['id'] }}">{{ json_encode($items) }}</textarea>
+                    </div>
+                  @else
+                    <p class="text-muted mb-0">{{ $element['label'] }}</p>
+                  @endif
+                </div>
+              @endforeach
+            </div>
+          </div>
+        @endforeach
+      </div>
+      <div class="col-md-8 position-sticky" style="top:0;height:100vh">
+        <iframe id="page-preview" src="{{ $previewUrl }}" class="w-100 border h-100"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+const csrf = '{{ csrf_token() }}';
+
+function reloadPreview() {
+  const iframe = document.getElementById('page-preview');
+  iframe.contentWindow.location.reload();
+}
+
+document.querySelectorAll('#elements [data-key]').forEach(function(input){
+  input.addEventListener('change', function(){
+    const key = this.getAttribute('data-key');
+    const formData = new FormData();
+    formData.append('key', key);
+    if(this.type === 'checkbox'){
+      formData.append('value', this.checked ? 1 : 0);
+    }else if(this.type === 'file'){
+      if(this.files[0]){ formData.append('value', this.files[0]); }
+    }else{
+      formData.append('value', this.value);
+    }
+
+    fetch('{{ route('admin.pages.cart.update') }}', {
+      method: 'POST',
+      headers: {'X-CSRF-TOKEN': csrf},
+      body: formData
+    }).then(() => reloadPreview());
+  });
+});
+
+document.querySelectorAll('[data-repeatable]').forEach(function(wrapper){
+  const itemsContainer = wrapper.querySelector('.repeatable-items');
+  const hidden = wrapper.querySelector('[data-key]');
+  const fields = JSON.parse(wrapper.getAttribute('data-fields') || '[]');
+
+  function buildItem(data = {}){
+    const div = document.createElement('div');
+    div.className = 'repeatable-item mb-2';
+    let html = '';
+    fields.forEach(function(field){
+      if((field.type || 'text') === 'textarea'){
+        html += `<textarea class="form-control mb-1" data-field="${field.name}" placeholder="${field.placeholder}">${data[field.name] || ''}</textarea>`;
+      }else{
+        html += `<input type="text" class="form-control mb-1" data-field="${field.name}" placeholder="${field.placeholder}" value="${data[field.name] || ''}">`;
+      }
+    });
+    html += '<button type="button" class="btn btn-sm btn-danger remove-item">Remove</button>';
+    div.innerHTML = html;
+    return div;
+  }
+
+  function sync(){
+    const data = [];
+    itemsContainer.querySelectorAll('.repeatable-item').forEach(function(item){
+      const obj = {};
+      item.querySelectorAll('[data-field]').forEach(function(input){
+        obj[input.getAttribute('data-field')] = input.value;
+      });
+      data.push(obj);
+    });
+    hidden.value = JSON.stringify(data);
+    hidden.dispatchEvent(new Event('change'));
+  }
+
+  wrapper.querySelector('.add-item').addEventListener('click', function(){
+    itemsContainer.appendChild(buildItem());
+  });
+
+  itemsContainer.addEventListener('input', sync);
+  itemsContainer.addEventListener('click', function(e){
+    if(e.target.classList.contains('remove-item')){
+      e.target.closest('.repeatable-item').remove();
+      sync();
+    }
+  });
+
+  try {
+    JSON.parse(hidden.value || '[]').forEach(function(item){
+      itemsContainer.appendChild(buildItem(item));
+    });
+  } catch(e) {}
+
+  sync();
+});
+
+document.querySelectorAll('#elements .card').forEach(function(card){
+  card.addEventListener('mouseenter', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '2px dashed #ff9800';
+      section.scrollIntoView({behavior:'smooth'});
+    }
+  });
+  card.addEventListener('mouseleave', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '';
+    }
+  });
+});
+</script>
+@endsection

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -105,6 +105,7 @@
                   <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/home')}}">Home</a></li>
                   <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/product')}}">Produk</a></li>
                   <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/product-detail')}}">Detail Produk</a></li>
+                  <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/cart')}}">Keranjang</a></li>
                 </ul>
               </div>
             </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Models\Product;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ThemeAssetController;
+use App\Http\Controllers\CartController;
 use App\Http\Controllers\Admin\ThemeController;
 use App\Http\Controllers\Admin\TagController;
 use App\Http\Controllers\Admin\ProductController;
@@ -58,6 +59,11 @@ Route::get('/produk/{product}', function (Product $product) {
     abort(404);
 })->name('products.show');
 
+Route::get('/keranjang', [CartController::class, 'index'])->name('cart.index');
+Route::post('/cart/items', [CartController::class, 'store'])->name('cart.items.store');
+Route::patch('/cart/items/{product}', [CartController::class, 'update'])->name('cart.items.update');
+Route::delete('/cart/items/{product}', [CartController::class, 'destroy'])->name('cart.items.destroy');
+
 Route::get('themes/{theme}/assets/{path}', ThemeAssetController::class)
     ->where('path', '.*')
     ->name('themes.assets');
@@ -109,4 +115,6 @@ Route::prefix('admin')/* ->middleware(['auth']) */->group(function () {
     Route::get('pages/product-detail', [PageController::class, 'productDetail'])->name('admin.pages.product-detail');
     Route::post('pages/product-detail', [PageController::class, 'updateProductDetail'])->name('admin.pages.product-detail.update');
     Route::patch('pages/product-detail/comments/{comment}', [PageController::class, 'toggleComment'])->name('admin.pages.product-detail.comments.toggle');
+    Route::get('pages/cart', [PageController::class, 'cart'])->name('admin.pages.cart');
+    Route::post('pages/cart', [PageController::class, 'updateCart'])->name('admin.pages.cart.update');
 });

--- a/themes/theme-herbalgreen/views/cart.blade.php
+++ b/themes/theme-herbalgreen/views/cart.blade.php
@@ -1,0 +1,422 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Keranjang</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+    <style>
+        #cart {
+            padding: 4rem 2rem;
+        }
+
+        #cart h1 {
+            text-align: center;
+            margin-bottom: 1rem;
+        }
+
+        #cart p.subtitle {
+            text-align: center;
+            color: #4a4a4a;
+            margin-bottom: 2.5rem;
+        }
+
+        .cart-table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #fff;
+            box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+            border-radius: 12px;
+            overflow: hidden;
+        }
+
+        .cart-table th,
+        .cart-table td {
+            padding: 1.25rem;
+            text-align: left;
+        }
+
+        .cart-table thead {
+            background: var(--color-primary);
+            color: #fff;
+        }
+
+        .cart-item {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .cart-item img {
+            width: 80px;
+            height: 80px;
+            object-fit: cover;
+            border-radius: 12px;
+        }
+
+        .quantity-control {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid var(--color-secondary);
+            border-radius: 999px;
+            overflow: hidden;
+        }
+
+        .quantity-control button {
+            background: transparent;
+            border: none;
+            padding: 0.5rem 0.9rem;
+            cursor: pointer;
+            font-size: 1rem;
+            color: var(--color-primary);
+        }
+
+        .quantity-control input {
+            width: 60px;
+            text-align: center;
+            border: none;
+            font-size: 1rem;
+            padding: 0.5rem 0;
+        }
+
+        .cart-remove {
+            background: none;
+            border: none;
+            color: #d32f2f;
+            font-size: 1.25rem;
+            cursor: pointer;
+        }
+
+        .cart-summary {
+            margin-top: 2rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            align-items: flex-end;
+        }
+
+        .cart-summary .total-line {
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+
+        .cart-actions {
+            display: flex;
+            gap: 1rem;
+        }
+
+        .cart-actions .cta {
+            border-radius: 30px;
+        }
+
+        .cart-empty {
+            text-align: center;
+            padding: 3rem;
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 4px 16px rgba(0,0,0,0.05);
+        }
+
+        .cart-empty p {
+            margin-bottom: 1.5rem;
+        }
+
+        .cart-feedback {
+            text-align: right;
+            color: var(--color-primary);
+            min-height: 1.5rem;
+        }
+
+        .cart-feedback.error {
+            color: #d32f2f;
+        }
+
+        @media (max-width: 768px) {
+            .cart-table thead {
+                display: none;
+            }
+
+            .cart-table tr {
+                display: grid;
+                grid-template-columns: repeat(2, 1fr);
+                gap: 0.75rem;
+                padding: 1rem;
+                border-bottom: 1px solid #e0f2f1;
+            }
+
+            .cart-table td {
+                padding: 0;
+            }
+
+            .cart-table td:last-child {
+                justify-self: end;
+            }
+
+            .cart-summary {
+                align-items: stretch;
+            }
+
+            .cart-actions {
+                flex-direction: column;
+            }
+        }
+    </style>
+</head>
+<body>
+@php
+    use App\Support\Cart;
+
+    $settings = $settings ?? collect();
+    $cartSummary = $cartSummary ?? Cart::summary();
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
+    ];
+    $footerLinks = [
+        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => ($settings['footer.privacy'] ?? '0') == '1'],
+        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => ($settings['footer.terms'] ?? '0') == '1'],
+    ];
+    $title = $settings['title'] ?? 'Keranjang';
+    $subtitle = $settings['subtitle'] ?? 'Periksa kembali item pesanan Anda sebelum melanjutkan.';
+    $emptyMessage = $settings['empty.message'] ?? 'Keranjang Anda masih kosong.';
+    $emptyButton = $settings['empty.button'] ?? 'Belanja Sekarang';
+    $shippingLabel = $settings['button.shipping'] ?? 'Lanjut ke Pengiriman';
+    $paymentLabel = $settings['button.payment'] ?? 'Lanjut ke Pembayaran';
+    $primaryButton = $shippingEnabled ? $shippingLabel : $paymentLabel;
+@endphp
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+
+<section id="cart">
+    <h1>{{ $title }}</h1>
+    <p class="subtitle">{{ $subtitle }}</p>
+
+    <div id="cart-content" @class(['d-none' => empty($cartSummary['items'])])>
+        <table class="cart-table">
+            <thead>
+                <tr>
+                    <th>Produk</th>
+                    <th>Harga</th>
+                    <th>Kuantitas</th>
+                    <th>Subtotal</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody data-cart-body>
+                @foreach($cartSummary['items'] as $item)
+                    <tr data-product-id="{{ $item['product_id'] }}">
+                        <td>
+                            <div class="cart-item">
+                                <img src="{{ $item['image_url'] }}" alt="{{ $item['name'] }}">
+                                <div>
+                                    <a href="{{ $item['product_url'] }}">{{ $item['name'] }}</a>
+                                </div>
+                            </div>
+                        </td>
+                        <td>Rp <span data-item-price>{{ $item['price_formatted'] }}</span></td>
+                        <td>
+                            <div class="quantity-control" data-quantity-control>
+                                <button type="button" data-action="decrease">-</button>
+                                <input type="number" value="{{ $item['quantity'] }}" min="1">
+                                <button type="button" data-action="increase">+</button>
+                            </div>
+                        </td>
+                        <td>Rp <span data-item-subtotal>{{ $item['subtotal_formatted'] }}</span></td>
+                        <td class="text-right"><button type="button" class="cart-remove" data-remove-item>&times;</button></td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+        <div class="cart-summary">
+            <div class="cart-feedback" data-cart-status></div>
+            <div class="total-line">Total: Rp <span data-cart-grand-total>{{ $cartSummary['total_price_formatted'] }}</span></div>
+            <div class="cart-actions">
+                <a href="{{ url('/produk') }}" class="cta" style="background: transparent; color: var(--color-primary); border:1px solid var(--color-primary);">Lanjut Belanja</a>
+                <button class="cta" data-cart-action {{ empty($cartSummary['items']) ? 'disabled' : '' }}>{{ $primaryButton }}</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="cart-empty" class="cart-empty" @class(['d-none' => !empty($cartSummary['items'])])>
+        <p>{{ $emptyMessage }}</p>
+        <a href="{{ url('/produk') }}" class="cta">{{ $emptyButton }}</a>
+    </div>
+</section>
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
+    'links' => $footerLinks,
+    'copyright' => $settings['footer.copyright'] ?? ('© ' . date('Y') . ' Herbal Green')
+])->render() !!}
+
+<script>
+    (function(){
+        const csrf = '{{ csrf_token() }}';
+        const updateUrl = '{{ route('cart.items.update', ['product' => '__ID__']) }}';
+        const destroyUrl = '{{ route('cart.items.destroy', ['product' => '__ID__']) }}';
+        const cartBody = document.querySelector('[data-cart-body]');
+        const cartContent = document.getElementById('cart-content');
+        const emptyState = document.getElementById('cart-empty');
+        const status = document.querySelector('[data-cart-status]');
+        const totalDisplay = document.querySelector('[data-cart-grand-total]');
+        const actionButton = document.querySelector('[data-cart-action]');
+
+        function buildRow(item){
+            const tr = document.createElement('tr');
+            tr.dataset.productId = item.product_id;
+
+            const infoCell = document.createElement('td');
+            const wrapper = document.createElement('div');
+            wrapper.className = 'cart-item';
+            const img = document.createElement('img');
+            img.src = item.image_url;
+            img.alt = item.name;
+            const info = document.createElement('div');
+            const link = document.createElement('a');
+            link.href = item.product_url;
+            link.textContent = item.name;
+            info.appendChild(link);
+            wrapper.appendChild(img);
+            wrapper.appendChild(info);
+            infoCell.appendChild(wrapper);
+
+            const priceCell = document.createElement('td');
+            priceCell.innerHTML = 'Rp <span data-item-price>' + item.price_formatted + '</span>';
+
+            const quantityCell = document.createElement('td');
+            const control = document.createElement('div');
+            control.className = 'quantity-control';
+            control.setAttribute('data-quantity-control', 'true');
+            control.innerHTML = '<button type="button" data-action="decrease">-</button>' +
+                '<input type="number" value="' + item.quantity + '" min="1">' +
+                '<button type="button" data-action="increase">+</button>';
+            quantityCell.appendChild(control);
+
+            const subtotalCell = document.createElement('td');
+            subtotalCell.innerHTML = 'Rp <span data-item-subtotal>' + item.subtotal_formatted + '</span>';
+
+            const actionCell = document.createElement('td');
+            actionCell.className = 'text-right';
+            const removeBtn = document.createElement('button');
+            removeBtn.type = 'button';
+            removeBtn.className = 'cart-remove';
+            removeBtn.setAttribute('data-remove-item', 'true');
+            removeBtn.textContent = '×';
+            actionCell.appendChild(removeBtn);
+
+            tr.append(infoCell, priceCell, quantityCell, subtotalCell, actionCell);
+            return tr;
+        }
+
+        function showStatus(message, isError = false){
+            if(!status) return;
+            status.textContent = message;
+            status.classList.toggle('error', !!isError);
+            if(message){
+                status.classList.add('visible');
+                setTimeout(() => status.classList.remove('visible'), 2500);
+            }
+        }
+
+        function applySummary(summary){
+            if(!cartBody || !summary) return;
+            const items = summary.items || [];
+            cartBody.innerHTML = '';
+            items.forEach(item => cartBody.appendChild(buildRow(item)));
+            if(totalDisplay){
+                totalDisplay.textContent = summary.total_price_formatted || '0';
+            }
+            if(actionButton){
+                actionButton.disabled = items.length === 0;
+            }
+            if(items.length === 0){
+                cartContent?.classList.add('d-none');
+                emptyState?.classList.remove('d-none');
+            }else{
+                cartContent?.classList.remove('d-none');
+                emptyState?.classList.add('d-none');
+            }
+            window.dispatchEvent(new CustomEvent('cart:updated', { detail: summary }));
+        }
+
+        function handleResponse(response){
+            if(!response.ok){
+                throw new Error('Request failed');
+            }
+            return response.json();
+        }
+
+        function updateQuantity(productId, quantity){
+            fetch(updateUrl.replace('__ID__', productId), {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-CSRF-TOKEN': csrf,
+                },
+                body: JSON.stringify({ quantity: quantity })
+            })
+            .then(handleResponse)
+            .then(data => {
+                applySummary(data.summary);
+                showStatus('Jumlah produk diperbarui.');
+            })
+            .catch(() => showStatus('Gagal memperbarui keranjang.', true));
+        }
+
+        function removeItem(productId){
+            fetch(destroyUrl.replace('__ID__', productId), {
+                method: 'DELETE',
+                headers: {
+                    'Accept': 'application/json',
+                    'X-CSRF-TOKEN': csrf,
+                }
+            })
+            .then(handleResponse)
+            .then(data => {
+                applySummary(data.summary);
+                showStatus('Produk dihapus dari keranjang.');
+            })
+            .catch(() => showStatus('Gagal menghapus produk.', true));
+        }
+
+        if(cartBody){
+            cartBody.addEventListener('click', function(event){
+                const button = event.target.closest('button[data-action]');
+                if(button){
+                    const row = button.closest('tr[data-product-id]');
+                    const input = row?.querySelector('input[type="number"]');
+                    if(!row || !input) return;
+                    let value = parseInt(input.value || '1', 10);
+                    if(button.dataset.action === 'increase') value += 1;
+                    if(button.dataset.action === 'decrease') value = Math.max(1, value - 1);
+                    input.value = value;
+                    updateQuantity(row.dataset.productId, value);
+                    return;
+                }
+                const remove = event.target.closest('[data-remove-item]');
+                if(remove){
+                    const row = remove.closest('tr[data-product-id]');
+                    if(!row) return;
+                    removeItem(row.dataset.productId);
+                }
+            });
+
+            cartBody.addEventListener('change', function(event){
+                const input = event.target;
+                if(input.matches('input[type="number"]')){
+                    const row = input.closest('tr[data-product-id]');
+                    if(!row) return;
+                    let value = parseInt(input.value || '1', 10);
+                    if(isNaN(value) || value < 1){
+                        value = 1;
+                        input.value = value;
+                    }
+                    updateQuantity(row.dataset.productId, value);
+                }
+            });
+        }
+    })();
+</script>
+</body>
+</html>

--- a/themes/theme-herbalgreen/views/components/nav-menu.blade.php
+++ b/themes/theme-herbalgreen/views/components/nav-menu.blade.php
@@ -1,3 +1,6 @@
+@php
+    $cartSummary = $cart ?? ['total_quantity' => 0, 'total_price_formatted' => '0'];
+@endphp
 <header id="navigation" class="site-header">
     <div class="logo">TEA</div>
     <nav class="main-nav">
@@ -12,6 +15,85 @@
     <div class="header-icons">
         <span>🔍</span>
         <span>👤</span>
-        <span>🛒</span>
+        <a href="{{ route('cart.index') }}" class="cart-indicator" data-cart-link>
+            <span class="icon">🛒</span>
+            <span class="cart-count" data-cart-count data-count="{{ $cartSummary['total_quantity'] ?? 0 }}">{{ $cartSummary['total_quantity'] ?? 0 }}</span>
+        </a>
     </div>
 </header>
+
+@once
+    <style>
+        .cart-indicator {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            text-decoration: none;
+            color: inherit;
+            position: relative;
+        }
+
+        .cart-count {
+            min-width: 1.75rem;
+            height: 1.75rem;
+            border-radius: 999px;
+            background: var(--color-primary);
+            color: #fff;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        .cart-count.cart-bounce {
+            animation: cartBounce 0.6s ease;
+        }
+
+        @keyframes cartBounce {
+            0%, 100% {
+                transform: scale(1);
+            }
+            30% {
+                transform: scale(1.2);
+            }
+            50% {
+                transform: scale(0.92);
+            }
+        }
+    </style>
+    <script>
+        (function () {
+            const initialSummary = @json($cartSummary);
+
+            function updateCartIndicator(summary, animate = true) {
+                document.querySelectorAll('[data-cart-count]').forEach(function (el) {
+                    const next = summary && typeof summary.total_quantity !== 'undefined' ? summary.total_quantity : 0;
+                    const prev = parseInt(el.dataset.count || '0', 10);
+                    el.textContent = next;
+                    el.dataset.count = next;
+                    if (animate && prev !== next) {
+                        el.classList.remove('cart-bounce');
+                        void el.offsetWidth;
+                        el.classList.add('cart-bounce');
+                        setTimeout(function () {
+                            el.classList.remove('cart-bounce');
+                        }, 600);
+                    }
+                });
+
+                document.querySelectorAll('[data-cart-total]').forEach(function (el) {
+                    el.textContent = summary && summary.total_price_formatted ? summary.total_price_formatted : '0';
+                });
+            }
+
+            document.addEventListener('DOMContentLoaded', function () {
+                updateCartIndicator(initialSummary, false);
+            });
+
+            window.addEventListener('cart:updated', function (event) {
+                updateCartIndicator(event.detail || {}, true);
+            });
+        })();
+    </script>
+@endonce

--- a/themes/theme-herbalgreen/views/home.blade.php
+++ b/themes/theme-herbalgreen/views/home.blade.php
@@ -11,6 +11,7 @@
 @php
     use App\Models\PageSetting;
     use App\Models\Product;
+    use App\Support\Cart;
     $settings = PageSetting::where('theme', $theme)->where('page', 'home')->pluck('value', 'key')->toArray();
     $products = Product::where('is_featured', true)->latest()->take(5)->get();
     $testimonials = json_decode($settings['testimonials.items'] ?? '[]', true);
@@ -27,8 +28,9 @@
         ['label' => 'Privacy Policy', 'href' => '#', 'visible' => ($settings['footer.privacy'] ?? '1') == '1'],
         ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => ($settings['footer.terms'] ?? '1') == '1'],
     ];
+    $cartSummary = Cart::summary();
 @endphp
-{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
 
 @if(($settings['hero.visible'] ?? '1') == '1')
 <section id="hero" class="hero" @if(!empty($settings['hero.image'])) style="background-image:url('{{ asset('storage/'.$settings['hero.image']) }}')" @endif>

--- a/themes/theme-herbalgreen/views/product.blade.php
+++ b/themes/theme-herbalgreen/views/product.blade.php
@@ -12,6 +12,7 @@
     use App\Models\PageSetting;
     use App\Models\Product;
     use App\Models\Category;
+    use App\Support\Cart;
     $settings = PageSetting::where('theme', $theme)->where('page', 'product')->pluck('value', 'key')->toArray();
     $query = Product::query();
     if($s = request('search')){ $query->where('name', 'like', "%$s%"); }
@@ -26,9 +27,11 @@
     $navLinks = [
         ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
         ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
     ];
+    $cartSummary = Cart::summary();
 @endphp
-{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
 @if(($settings['hero.visible'] ?? '1') == '1')
 <section id="hero" class="hero" @if(!empty($settings['hero.image'])) style="background-image:url('{{ asset('storage/'.$settings['hero.image']) }}')" @endif>
     <div class="hero-content">

--- a/themes/theme-restoran/views/cart.blade.php
+++ b/themes/theme-restoran/views/cart.blade.php
@@ -1,0 +1,381 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Keranjang</title>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <link href="{{ asset('storage/themes/theme-restoran/img/favicon.ico') }}" rel="icon">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600&family=Nunito:wght@600;700;800&family=Pacifico&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.0/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/animate/animate.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/assets/owl.carousel.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/css/tempusdominus-bootstrap-4.min.css') }}" rel="stylesheet" />
+    <link href="{{ asset('storage/themes/theme-restoran/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/css/style.css') }}" rel="stylesheet">
+    <style>
+        .cart-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .cart-table thead {
+            background: var(--bs-dark);
+            color: #fff;
+        }
+
+        .cart-table th,
+        .cart-table td {
+            padding: 1.25rem 1rem;
+            vertical-align: middle;
+        }
+
+        .cart-table tbody tr {
+            border-bottom: 1px solid rgba(0,0,0,0.05);
+        }
+
+        .cart-item {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .cart-item img {
+            width: 90px;
+            height: 90px;
+            object-fit: cover;
+            border-radius: 12px;
+        }
+
+        .quantity-control {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid rgba(0,0,0,0.1);
+            border-radius: 999px;
+            overflow: hidden;
+        }
+
+        .quantity-control button {
+            background: rgba(0,0,0,0.05);
+            border: none;
+            padding: 0.5rem 0.9rem;
+            font-size: 1rem;
+            color: var(--bs-dark);
+        }
+
+        .quantity-control input {
+            width: 60px;
+            text-align: center;
+            border: none;
+            font-size: 1rem;
+        }
+
+        .cart-remove {
+            background: none;
+            border: none;
+            font-size: 1.4rem;
+            color: #dc3545;
+        }
+
+        .cart-feedback {
+            color: var(--bs-primary);
+            min-height: 1.5rem;
+            text-align: right;
+        }
+
+        .cart-feedback.error {
+            color: #dc3545;
+        }
+
+        .cart-empty {
+            text-align: center;
+            padding: 3rem 1.5rem;
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 15px 40px rgba(0,0,0,0.08);
+        }
+
+        .cart-empty p {
+            margin-bottom: 1.5rem;
+        }
+    </style>
+</head>
+<body>
+@php
+    use App\Support\Cart;
+
+    $settings = $settings ?? collect();
+    $cartSummary = $cartSummary ?? Cart::summary();
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
+    ];
+    $title = $settings['title'] ?? 'Keranjang';
+    $subtitle = $settings['subtitle'] ?? 'Nikmati kemudahan berbelanja dengan memeriksa pesanan Anda di sini.';
+    $emptyMessage = $settings['empty.message'] ?? 'Keranjang masih kosong, mulai belanja sekarang!';
+    $emptyButton = $settings['empty.button'] ?? 'Belanja Sekarang';
+    $shippingLabel = $settings['button.shipping'] ?? 'Lanjut ke Pengiriman';
+    $paymentLabel = $settings['button.payment'] ?? 'Lanjut ke Pembayaran';
+    $primaryButton = $shippingEnabled ? $shippingLabel : $paymentLabel;
+@endphp
+
+<div class="container-xxl position-relative p-0">
+    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+    <div class="container-xxl py-5 bg-dark hero-header mb-5">
+        <div class="container text-center my-5 pt-5 pb-4">
+            <h1 class="display-3 text-white mb-3">{{ $title }}</h1>
+            <p class="text-white-50 mb-0">{{ $subtitle }}</p>
+        </div>
+    </div>
+</div>
+
+<div class="container py-5">
+    <div id="cart-content" @class(['d-none' => empty($cartSummary['items'])])>
+        <div class="table-responsive mb-4">
+            <table class="cart-table">
+                <thead>
+                    <tr>
+                        <th>Produk</th>
+                        <th>Harga</th>
+                        <th>Kuantitas</th>
+                        <th>Subtotal</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody data-cart-body>
+                    @foreach($cartSummary['items'] as $item)
+                        <tr data-product-id="{{ $item['product_id'] }}">
+                            <td>
+                                <div class="cart-item">
+                                    <img src="{{ $item['image_url'] }}" alt="{{ $item['name'] }}">
+                                    <div>
+                                        <h5 class="mb-1"><a href="{{ $item['product_url'] }}" class="text-dark">{{ $item['name'] }}</a></h5>
+                                    </div>
+                                </div>
+                            </td>
+                            <td>Rp <span data-item-price>{{ $item['price_formatted'] }}</span></td>
+                            <td>
+                                <div class="quantity-control" data-quantity-control>
+                                    <button type="button" data-action="decrease">-</button>
+                                    <input type="number" value="{{ $item['quantity'] }}" min="1">
+                                    <button type="button" data-action="increase">+</button>
+                                </div>
+                            </td>
+                            <td>Rp <span data-item-subtotal>{{ $item['subtotal_formatted'] }}</span></td>
+                            <td class="text-end"><button type="button" class="cart-remove" data-remove-item>&times;</button></td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        <div class="row g-4 align-items-center">
+            <div class="col-lg-6">
+                <div class="cart-feedback" data-cart-status></div>
+                <a href="{{ url('/produk') }}" class="btn btn-outline-primary">Lanjut Belanja</a>
+            </div>
+            <div class="col-lg-6 text-lg-end">
+                <div class="d-inline-flex flex-column align-items-end gap-3">
+                    <div class="fs-4 fw-bold">Total: Rp <span data-cart-grand-total>{{ $cartSummary['total_price_formatted'] }}</span></div>
+                    <button class="btn btn-primary btn-lg" data-cart-action {{ empty($cartSummary['items']) ? 'disabled' : '' }}>{{ $primaryButton }}</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="cart-empty" class="cart-empty" @class(['d-none' => !empty($cartSummary['items'])])>
+        <h3 class="mb-3">{{ $title }}</h3>
+        <p class="text-muted">{{ $subtitle }}</p>
+        <p>{{ $emptyMessage }}</p>
+        <a href="{{ url('/produk') }}" class="btn btn-primary">{{ $emptyButton }}</a>
+    </div>
+</div>
+
+{!! view()->file(base_path('themes/theme-restoran/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+
+<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/wow/wow.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/easing/easing.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/waypoints/waypoints.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/counterup/counterup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment-timezone.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/tempusdominus-bootstrap-4.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/js/main.js') }}"></script>
+<script>
+    (function(){
+        const csrf = '{{ csrf_token() }}';
+        const updateUrl = '{{ route('cart.items.update', ['product' => '__ID__']) }}';
+        const destroyUrl = '{{ route('cart.items.destroy', ['product' => '__ID__']) }}';
+        const cartBody = document.querySelector('[data-cart-body]');
+        const cartContent = document.getElementById('cart-content');
+        const emptyState = document.getElementById('cart-empty');
+        const status = document.querySelector('[data-cart-status]');
+        const totalDisplay = document.querySelector('[data-cart-grand-total]');
+        const actionButton = document.querySelector('[data-cart-action]');
+
+        function buildRow(item){
+            const tr = document.createElement('tr');
+            tr.dataset.productId = item.product_id;
+
+            const infoCell = document.createElement('td');
+            const wrapper = document.createElement('div');
+            wrapper.className = 'cart-item';
+            const img = document.createElement('img');
+            img.src = item.image_url;
+            img.alt = item.name;
+            const info = document.createElement('div');
+            const title = document.createElement('h5');
+            title.className = 'mb-1';
+            const link = document.createElement('a');
+            link.href = item.product_url;
+            link.className = 'text-dark';
+            link.textContent = item.name;
+            title.appendChild(link);
+            info.appendChild(title);
+            wrapper.appendChild(img);
+            wrapper.appendChild(info);
+            infoCell.appendChild(wrapper);
+
+            const priceCell = document.createElement('td');
+            priceCell.innerHTML = 'Rp <span data-item-price>' + item.price_formatted + '</span>';
+
+            const quantityCell = document.createElement('td');
+            const control = document.createElement('div');
+            control.className = 'quantity-control';
+            control.setAttribute('data-quantity-control', 'true');
+            control.innerHTML = '<button type="button" data-action="decrease">-</button>' +
+                '<input type="number" value="' + item.quantity + '" min="1">' +
+                '<button type="button" data-action="increase">+</button>';
+            quantityCell.appendChild(control);
+
+            const subtotalCell = document.createElement('td');
+            subtotalCell.innerHTML = 'Rp <span data-item-subtotal>' + item.subtotal_formatted + '</span>';
+
+            const actionCell = document.createElement('td');
+            actionCell.className = 'text-end';
+            const removeBtn = document.createElement('button');
+            removeBtn.type = 'button';
+            removeBtn.className = 'cart-remove';
+            removeBtn.setAttribute('data-remove-item', 'true');
+            removeBtn.textContent = '×';
+            actionCell.appendChild(removeBtn);
+
+            tr.append(infoCell, priceCell, quantityCell, subtotalCell, actionCell);
+            return tr;
+        }
+
+        function showStatus(message, isError = false){
+            if(!status) return;
+            status.textContent = message;
+            status.classList.toggle('error', !!isError);
+            if(message){
+                setTimeout(() => status.textContent = '', 2500);
+            }
+        }
+
+        function applySummary(summary){
+            if(!cartBody || !summary) return;
+            const items = summary.items || [];
+            cartBody.innerHTML = '';
+            items.forEach(item => cartBody.appendChild(buildRow(item)));
+            if(totalDisplay){
+                totalDisplay.textContent = summary.total_price_formatted || '0';
+            }
+            if(actionButton){
+                actionButton.disabled = items.length === 0;
+            }
+            if(items.length === 0){
+                cartContent?.classList.add('d-none');
+                emptyState?.classList.remove('d-none');
+            }else{
+                cartContent?.classList.remove('d-none');
+                emptyState?.classList.add('d-none');
+            }
+            window.dispatchEvent(new CustomEvent('cart:updated', { detail: summary }));
+        }
+
+        function handleResponse(response){
+            if(!response.ok){
+                throw response;
+            }
+            return response.json();
+        }
+
+        function updateQuantity(productId, quantity){
+            fetch(updateUrl.replace('__ID__', productId), {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-CSRF-TOKEN': csrf,
+                },
+                body: JSON.stringify({ quantity: quantity })
+            })
+            .then(handleResponse)
+            .then(data => {
+                applySummary(data.summary);
+                showStatus('Jumlah diperbarui.');
+            })
+            .catch(() => showStatus('Gagal memperbarui keranjang.', true));
+        }
+
+        function removeItem(productId){
+            fetch(destroyUrl.replace('__ID__', productId), {
+                method: 'DELETE',
+                headers: {
+                    'Accept': 'application/json',
+                    'X-CSRF-TOKEN': csrf,
+                }
+            })
+            .then(handleResponse)
+            .then(data => {
+                applySummary(data.summary);
+                showStatus('Produk dihapus dari keranjang.');
+            })
+            .catch(() => showStatus('Gagal menghapus produk.', true));
+        }
+
+        if(cartBody){
+            cartBody.addEventListener('click', function(event){
+                const button = event.target.closest('button[data-action]');
+                if(button){
+                    const row = button.closest('tr[data-product-id]');
+                    const input = row?.querySelector('input[type="number"]');
+                    if(!row || !input) return;
+                    let value = parseInt(input.value || '1', 10);
+                    if(button.dataset.action === 'increase') value += 1;
+                    if(button.dataset.action === 'decrease') value = Math.max(1, value - 1);
+                    input.value = value;
+                    updateQuantity(row.dataset.productId, value);
+                    return;
+                }
+                const remove = event.target.closest('[data-remove-item]');
+                if(remove){
+                    const row = remove.closest('tr[data-product-id]');
+                    if(!row) return;
+                    removeItem(row.dataset.productId);
+                }
+            });
+
+            cartBody.addEventListener('change', function(event){
+                const input = event.target;
+                if(input.matches('input[type="number"]')){
+                    const row = input.closest('tr[data-product-id]');
+                    if(!row) return;
+                    let value = parseInt(input.value || '1', 10);
+                    if(isNaN(value) || value < 1){
+                        value = 1;
+                        input.value = value;
+                    }
+                    updateQuantity(row.dataset.productId, value);
+                }
+            });
+        }
+    })();
+</script>
+</body>
+</html>

--- a/themes/theme-restoran/views/components/nav-menu.blade.php
+++ b/themes/theme-restoran/views/components/nav-menu.blade.php
@@ -1,3 +1,6 @@
+@php
+    $cartSummary = $cart ?? ['total_quantity' => 0, 'total_price_formatted' => '0'];
+@endphp
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark px-4 px-lg-5 py-3 py-lg-0">
     <a href="{{ url('/') }}" class="navbar-brand p-0">
         <h1 class="text-primary m-0"><i class="fa fa-utensils me-3"></i>Restoran</h1>
@@ -13,6 +16,74 @@
                 @endif
             @endforeach
         </div>
-        <a href="#" class="btn btn-primary py-2 px-4">Book A Table</a>
+        <div class="d-flex align-items-center gap-2">
+            <a href="{{ route('cart.index') }}" class="btn btn-outline-light cart-indicator position-relative">
+                <i class="bi bi-cart"></i>
+                <span class="badge bg-primary rounded-pill cart-count" data-cart-count data-count="{{ $cartSummary['total_quantity'] ?? 0 }}">{{ $cartSummary['total_quantity'] ?? 0 }}</span>
+            </a>
+            <a href="#" class="btn btn-primary py-2 px-4">Book A Table</a>
+        </div>
     </div>
 </nav>
+
+@once
+    <style>
+        .cart-indicator .cart-count {
+            position: absolute;
+            top: -0.4rem;
+            right: -0.6rem;
+            font-size: 0.75rem;
+            min-width: 1.5rem;
+        }
+
+        .cart-count.cart-bounce {
+            animation: cartBounce 0.6s ease;
+        }
+
+        @keyframes cartBounce {
+            0%, 100% {
+                transform: scale(1);
+            }
+            30% {
+                transform: scale(1.2);
+            }
+            50% {
+                transform: scale(0.92);
+            }
+        }
+    </style>
+    <script>
+        (function () {
+            const initialSummary = @json($cartSummary);
+
+            function updateCartIndicator(summary, animate = true) {
+                document.querySelectorAll('[data-cart-count]').forEach(function (el) {
+                    const next = summary && typeof summary.total_quantity !== 'undefined' ? summary.total_quantity : 0;
+                    const prev = parseInt(el.dataset.count || '0', 10);
+                    el.textContent = next;
+                    el.dataset.count = next;
+                    if (animate && prev !== next) {
+                        el.classList.remove('cart-bounce');
+                        void el.offsetWidth;
+                        el.classList.add('cart-bounce');
+                        setTimeout(function () {
+                            el.classList.remove('cart-bounce');
+                        }, 600);
+                    }
+                });
+
+                document.querySelectorAll('[data-cart-total]').forEach(function (el) {
+                    el.textContent = summary && summary.total_price_formatted ? summary.total_price_formatted : '0';
+                });
+            }
+
+            document.addEventListener('DOMContentLoaded', function () {
+                updateCartIndicator(initialSummary, false);
+            });
+
+            window.addEventListener('cart:updated', function (event) {
+                updateCartIndicator(event.detail || {}, true);
+            });
+        })();
+    </script>
+@endonce

--- a/themes/theme-restoran/views/home.blade.php
+++ b/themes/theme-restoran/views/home.blade.php
@@ -30,6 +30,7 @@
 @php
     use App\Models\PageSetting;
     use App\Models\Product;
+    use App\Support\Cart;
     $settings = PageSetting::where('theme', 'theme-restoran')->where('page', 'home')->pluck('value', 'key')->toArray();
     $products = Product::where('is_featured', true)->latest()->take(5)->get();
     $testimonials = json_decode($settings['testimonials.items'] ?? '[]', true);
@@ -41,9 +42,10 @@
         ['label' => 'Contact', 'href' => '#contact', 'visible' => ($settings['navigation.contact'] ?? '1') == '1'],
     ];
     $aboutImage = $settings['about.image'] ?? null;
+    $cartSummary = Cart::summary();
 @endphp
 <div class="container-xxl position-relative p-0">
-    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
     @if(($settings['hero.visible'] ?? '1') == '1')
     <div id="hero" class="container-xxl py-5 bg-dark hero-header mb-5">
         <div class="container my-5 py-5">

--- a/themes/theme-restoran/views/product.blade.php
+++ b/themes/theme-restoran/views/product.blade.php
@@ -21,6 +21,7 @@
     use App\Models\PageSetting;
     use App\Models\Product;
     use App\Models\Category;
+    use App\Support\Cart;
     $settings = PageSetting::where('theme', 'theme-restoran')->where('page', 'product')->pluck('value','key')->toArray();
     $query = Product::query();
     if($s = request('search')){ $query->where('name','like',"%$s%"); }
@@ -35,10 +36,12 @@
     $navLinks = [
         ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
         ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
     ];
+    $cartSummary = Cart::summary();
 @endphp
 <div class="container-xxl position-relative p-0">
-    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
     <div class="container-xxl py-5 bg-dark hero-header mb-5">
         <div class="container text-center my-5 pt-5 pb-4">
             <h1 class="display-3 text-white mb-3">{{ $settings['title'] ?? 'Produk Kami' }}</h1>

--- a/themes/theme-second/views/cart.blade.php
+++ b/themes/theme-second/views/cart.blade.php
@@ -1,0 +1,414 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Keranjang</title>
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/bootstrap.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/font-awesome.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/elegant-icons.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/nice-select.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/jquery-ui.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/owl.carousel.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/slicknav.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/style.css') }}" type="text/css">
+    <style>
+        .breadcrumb__text h1 {
+            font-size: 46px;
+            color: #ffffff;
+            font-weight: 700;
+            text-transform: uppercase;
+            margin-bottom: 10px;
+        }
+
+        .shoping__cart__table table {
+            width: 100%;
+        }
+
+        .shoping__cart__table table thead {
+            background: #f5f5f5;
+        }
+
+        .shoping__cart__table table thead th {
+            font-size: 1rem;
+            color: #1c1c1c;
+            font-weight: 600;
+            padding: 1rem 1.5rem;
+            text-transform: uppercase;
+        }
+
+        .shoping__cart__table table tbody tr td {
+            padding: 1.25rem 1.5rem;
+            vertical-align: middle;
+            border-bottom: 1px solid #f2f2f2;
+        }
+
+        .cart__product__item {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .cart__product__item img {
+            width: 80px;
+            height: 80px;
+            object-fit: cover;
+            border-radius: 8px;
+        }
+
+        .quantity-control {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #ebebeb;
+            border-radius: 999px;
+            overflow: hidden;
+        }
+
+        .quantity-control button {
+            background: #f5f5f5;
+            border: none;
+            padding: 0.5rem 0.9rem;
+            font-size: 1rem;
+            cursor: pointer;
+            color: #1c1c1c;
+        }
+
+        .quantity-control input {
+            width: 60px;
+            text-align: center;
+            border: none;
+            font-size: 1rem;
+        }
+
+        .cart-remove {
+            background: none;
+            border: none;
+            color: #d32f2f;
+            font-size: 1.3rem;
+        }
+
+        .shoping__cart__total {
+            display: flex;
+            justify-content: space-between;
+            font-size: 1.25rem;
+            font-weight: 600;
+            padding: 1rem 1.5rem;
+            background: #f5f5f5;
+            border-radius: 8px;
+        }
+
+        .cart-feedback {
+            color: #7fad39;
+            min-height: 1.5rem;
+            text-align: right;
+        }
+
+        .cart-feedback.error {
+            color: #d32f2f;
+        }
+
+        .cart-empty {
+            text-align: center;
+            padding: 3rem 1rem;
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.08);
+        }
+
+        .cart-empty p {
+            margin-bottom: 1.5rem;
+        }
+    </style>
+</head>
+<body>
+@php
+    use App\Support\Cart;
+
+    $settings = $settings ?? collect();
+    $cartSummary = $cartSummary ?? Cart::summary();
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
+    ];
+    $title = $settings['title'] ?? 'Keranjang';
+    $subtitle = $settings['subtitle'] ?? 'Periksa kembali daftar belanja Anda.';
+    $emptyMessage = $settings['empty.message'] ?? 'Keranjang Anda masih kosong.';
+    $emptyButton = $settings['empty.button'] ?? 'Belanja Sekarang';
+    $shippingLabel = $settings['button.shipping'] ?? 'Lanjut ke Pengiriman';
+    $paymentLabel = $settings['button.payment'] ?? 'Lanjut ke Pembayaran';
+    $primaryButton = $shippingEnabled ? $shippingLabel : $paymentLabel;
+@endphp
+
+{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+
+<section class="breadcrumb-section set-bg" data-setbg="{{ asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <div class="breadcrumb__text">
+                    <h1>{{ $title }}</h1>
+                    <div class="breadcrumb__option">
+                        <a href="{{ url('/') }}">Home</a>
+                        <span>{{ $title }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="shoping-cart spad">
+    <div class="container">
+        <div class="row" id="cart-content" @class(['d-none' => empty($cartSummary['items'])])>
+            <div class="col-lg-12">
+                <div class="shoping__cart__table">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th class="shoping__product">Produk</th>
+                                <th>Harga</th>
+                                <th>Kuantitas</th>
+                                <th>Total</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody data-cart-body>
+                            @foreach($cartSummary['items'] as $item)
+                                <tr data-product-id="{{ $item['product_id'] }}">
+                                    <td class="shoping__cart__item">
+                                        <div class="cart__product__item">
+                                            <img src="{{ $item['image_url'] }}" alt="{{ $item['name'] }}">
+                                            <div class="cart__product__item__title">
+                                                <h6><a href="{{ $item['product_url'] }}">{{ $item['name'] }}</a></h6>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td class="shoping__cart__price">Rp <span data-item-price>{{ $item['price_formatted'] }}</span></td>
+                                    <td class="shoping__cart__quantity">
+                                        <div class="quantity-control" data-quantity-control>
+                                            <button type="button" data-action="decrease">-</button>
+                                            <input type="number" value="{{ $item['quantity'] }}" min="1">
+                                            <button type="button" data-action="increase">+</button>
+                                        </div>
+                                    </td>
+                                    <td class="shoping__cart__total">Rp <span data-item-subtotal>{{ $item['subtotal_formatted'] }}</span></td>
+                                    <td class="shoping__cart__item__close"><button type="button" class="cart-remove" data-remove-item>&times;</button></td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <div class="cart-feedback" data-cart-status></div>
+                <div class="shoping__cart__btns">
+                    <a href="{{ url('/produk') }}" class="primary-btn cart-btn">Lanjut Belanja</a>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <div class="shoping__checkout">
+                    <div class="shoping__cart__total">
+                        <span>Total</span>
+                        <span>Rp <span data-cart-grand-total>{{ $cartSummary['total_price_formatted'] }}</span></span>
+                    </div>
+                    <button class="primary-btn" data-cart-action {{ empty($cartSummary['items']) ? 'disabled' : '' }}>{{ $primaryButton }}</button>
+                </div>
+            </div>
+        </div>
+        <div id="cart-empty" class="cart-empty" @class(['d-none' => !empty($cartSummary['items'])])>
+            <h4>{{ $title }}</h4>
+            <p>{{ $subtitle }}</p>
+            <p>{{ $emptyMessage }}</p>
+            <a href="{{ url('/produk') }}" class="primary-btn">{{ $emptyButton }}</a>
+        </div>
+    </div>
+</section>
+
+{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+
+<script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.nice-select.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery-ui.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.slicknav.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/mixitup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/main.js') }}"></script>
+<script>
+    (function(){
+        const csrf = '{{ csrf_token() }}';
+        const updateUrl = '{{ route('cart.items.update', ['product' => '__ID__']) }}';
+        const destroyUrl = '{{ route('cart.items.destroy', ['product' => '__ID__']) }}';
+        const cartBody = document.querySelector('[data-cart-body]');
+        const cartContent = document.getElementById('cart-content');
+        const emptyState = document.getElementById('cart-empty');
+        const status = document.querySelector('[data-cart-status]');
+        const totalDisplay = document.querySelector('[data-cart-grand-total]');
+        const actionButton = document.querySelector('[data-cart-action]');
+
+        function buildRow(item){
+            const tr = document.createElement('tr');
+            tr.dataset.productId = item.product_id;
+
+            const productCell = document.createElement('td');
+            productCell.className = 'shoping__cart__item';
+            const wrapper = document.createElement('div');
+            wrapper.className = 'cart__product__item';
+            const img = document.createElement('img');
+            img.src = item.image_url;
+            img.alt = item.name;
+            const info = document.createElement('div');
+            info.className = 'cart__product__item__title';
+            const title = document.createElement('h6');
+            const link = document.createElement('a');
+            link.href = item.product_url;
+            link.textContent = item.name;
+            title.appendChild(link);
+            info.appendChild(title);
+            wrapper.appendChild(img);
+            wrapper.appendChild(info);
+            productCell.appendChild(wrapper);
+
+            const priceCell = document.createElement('td');
+            priceCell.className = 'shoping__cart__price';
+            priceCell.innerHTML = 'Rp <span data-item-price>' + item.price_formatted + '</span>';
+
+            const quantityCell = document.createElement('td');
+            quantityCell.className = 'shoping__cart__quantity';
+            const control = document.createElement('div');
+            control.className = 'quantity-control';
+            control.setAttribute('data-quantity-control', 'true');
+            control.innerHTML = '<button type="button" data-action="decrease">-</button>' +
+                '<input type="number" value="' + item.quantity + '" min="1">' +
+                '<button type="button" data-action="increase">+</button>';
+            quantityCell.appendChild(control);
+
+            const subtotalCell = document.createElement('td');
+            subtotalCell.className = 'shoping__cart__total';
+            subtotalCell.innerHTML = 'Rp <span data-item-subtotal>' + item.subtotal_formatted + '</span>';
+
+            const actionCell = document.createElement('td');
+            actionCell.className = 'shoping__cart__item__close';
+            const removeBtn = document.createElement('button');
+            removeBtn.type = 'button';
+            removeBtn.className = 'cart-remove';
+            removeBtn.setAttribute('data-remove-item', 'true');
+            removeBtn.textContent = '×';
+            actionCell.appendChild(removeBtn);
+
+            tr.append(productCell, priceCell, quantityCell, subtotalCell, actionCell);
+            return tr;
+        }
+
+        function showStatus(message, isError = false){
+            if(!status) return;
+            status.textContent = message;
+            status.classList.toggle('error', !!isError);
+            if(message){
+                setTimeout(() => status.textContent = '', 2500);
+            }
+        }
+
+        function applySummary(summary){
+            if(!cartBody || !summary) return;
+            const items = summary.items || [];
+            cartBody.innerHTML = '';
+            items.forEach(item => cartBody.appendChild(buildRow(item)));
+            if(totalDisplay){
+                totalDisplay.textContent = summary.total_price_formatted || '0';
+            }
+            if(actionButton){
+                actionButton.disabled = items.length === 0;
+            }
+            if(items.length === 0){
+                cartContent?.classList.add('d-none');
+                emptyState?.classList.remove('d-none');
+            }else{
+                cartContent?.classList.remove('d-none');
+                emptyState?.classList.add('d-none');
+            }
+            window.dispatchEvent(new CustomEvent('cart:updated', { detail: summary }));
+        }
+
+        function handleResponse(response){
+            if(!response.ok){
+                throw response;
+            }
+            return response.json();
+        }
+
+        function updateQuantity(productId, quantity){
+            fetch(updateUrl.replace('__ID__', productId), {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-CSRF-TOKEN': csrf,
+                },
+                body: JSON.stringify({ quantity: quantity })
+            })
+            .then(handleResponse)
+            .then(data => {
+                applySummary(data.summary);
+                showStatus('Jumlah diperbarui.');
+            })
+            .catch(() => showStatus('Gagal memperbarui keranjang.', true));
+        }
+
+        function removeItem(productId){
+            fetch(destroyUrl.replace('__ID__', productId), {
+                method: 'DELETE',
+                headers: {
+                    'Accept': 'application/json',
+                    'X-CSRF-TOKEN': csrf,
+                }
+            })
+            .then(handleResponse)
+            .then(data => {
+                applySummary(data.summary);
+                showStatus('Produk dihapus dari keranjang.');
+            })
+            .catch(() => showStatus('Gagal menghapus produk.', true));
+        }
+
+        if(cartBody){
+            cartBody.addEventListener('click', function(event){
+                const button = event.target.closest('button[data-action]');
+                if(button){
+                    const row = button.closest('tr[data-product-id]');
+                    const input = row?.querySelector('input[type="number"]');
+                    if(!row || !input) return;
+                    let value = parseInt(input.value || '1', 10);
+                    if(button.dataset.action === 'increase') value += 1;
+                    if(button.dataset.action === 'decrease') value = Math.max(1, value - 1);
+                    input.value = value;
+                    updateQuantity(row.dataset.productId, value);
+                    return;
+                }
+                const remove = event.target.closest('[data-remove-item]');
+                if(remove){
+                    const row = remove.closest('tr[data-product-id]');
+                    if(!row) return;
+                    removeItem(row.dataset.productId);
+                }
+            });
+
+            cartBody.addEventListener('change', function(event){
+                const input = event.target;
+                if(input.matches('input[type="number"]')){
+                    const row = input.closest('tr[data-product-id]');
+                    if(!row) return;
+                    let value = parseInt(input.value || '1', 10);
+                    if(isNaN(value) || value < 1){
+                        value = 1;
+                        input.value = value;
+                    }
+                    updateQuantity(row.dataset.productId, value);
+                }
+            });
+        }
+    })();
+</script>
+</body>
+</html>

--- a/themes/theme-second/views/components/nav-menu.blade.php
+++ b/themes/theme-second/views/components/nav-menu.blade.php
@@ -1,3 +1,6 @@
+@php
+    $cartSummary = $cart ?? ['total_quantity' => 0, 'total_price_formatted' => '0'];
+@endphp
 <header class="header">
     <div class="container">
         <div class="row">
@@ -21,9 +24,9 @@
                 <div class="header__cart">
                     <ul>
                         <li><a href="#"><i class="fa fa-heart"></i> <span>0</span></a></li>
-                        <li><a href="#"><i class="fa fa-shopping-bag"></i> <span>0</span></a></li>
+                        <li><a href="{{ route('cart.index') }}" class="cart-indicator"><i class="fa fa-shopping-bag"></i> <span class="cart-count" data-cart-count data-count="{{ $cartSummary['total_quantity'] ?? 0 }}">{{ $cartSummary['total_quantity'] ?? 0 }}</span></a></li>
                     </ul>
-                    <div class="header__cart__price">item: <span>$0.00</span></div>
+                    <div class="header__cart__price">item: <span data-cart-total>{{ $cartSummary['total_price_formatted'] ?? '0' }}</span></div>
                 </div>
             </div>
         </div>
@@ -32,3 +35,75 @@
         </div>
     </div>
 </header>
+
+@once
+    <style>
+        .cart-indicator {
+            position: relative;
+        }
+
+        .header__cart .cart-count {
+            min-width: 1.5rem;
+            height: 1.5rem;
+            border-radius: 999px;
+            background: #7fad39;
+            color: #fff;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .cart-count.cart-bounce {
+            animation: cartBounce 0.6s ease;
+        }
+
+        @keyframes cartBounce {
+            0%, 100% {
+                transform: scale(1);
+            }
+            30% {
+                transform: scale(1.2);
+            }
+            50% {
+                transform: scale(0.92);
+            }
+        }
+    </style>
+    <script>
+        (function () {
+            const initialSummary = @json($cartSummary);
+
+            function updateCartIndicator(summary, animate = true) {
+                document.querySelectorAll('[data-cart-count]').forEach(function (el) {
+                    const next = summary && typeof summary.total_quantity !== 'undefined' ? summary.total_quantity : 0;
+                    const prev = parseInt(el.dataset.count || '0', 10);
+                    el.textContent = next;
+                    el.dataset.count = next;
+                    if (animate && prev !== next) {
+                        el.classList.remove('cart-bounce');
+                        void el.offsetWidth;
+                        el.classList.add('cart-bounce');
+                        setTimeout(function () {
+                            el.classList.remove('cart-bounce');
+                        }, 600);
+                    }
+                });
+
+                document.querySelectorAll('[data-cart-total]').forEach(function (el) {
+                    el.textContent = summary && summary.total_price_formatted ? summary.total_price_formatted : '0';
+                });
+            }
+
+            document.addEventListener('DOMContentLoaded', function () {
+                updateCartIndicator(initialSummary, false);
+            });
+
+            window.addEventListener('cart:updated', function (event) {
+                updateCartIndicator(event.detail || {}, true);
+            });
+        })();
+    </script>
+@endonce

--- a/themes/theme-second/views/home.blade.php
+++ b/themes/theme-second/views/home.blade.php
@@ -20,6 +20,7 @@
 @php
     use App\Models\PageSetting;
     use App\Models\Product;
+    use App\Support\Cart;
     $settings = PageSetting::where('theme', 'theme-second')->where('page', 'home')->pluck('value', 'key')->toArray();
     $products = Product::where('is_featured', true)->latest()->take(5)->get();
     $testimonials = json_decode($settings['testimonials.items'] ?? '[]', true);
@@ -31,8 +32,9 @@
         ['label' => 'Contact Us', 'href' => '#contact', 'visible' => ($settings['navigation.contact'] ?? '1') == '1'],
     ];
     $aboutImage = $settings['about.image'] ?? null;
+    $cartSummary = Cart::summary();
 @endphp
-{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
 
 @if(($settings['hero.visible'] ?? '1') == '1')
 <section id="hero" class="hero">

--- a/themes/theme-second/views/product.blade.php
+++ b/themes/theme-second/views/product.blade.php
@@ -18,6 +18,7 @@
     use App\Models\PageSetting;
     use App\Models\Product;
     use App\Models\Category;
+    use App\Support\Cart;
     $settings = PageSetting::where('theme', 'theme-second')->where('page', 'product')->pluck('value', 'key')->toArray();
     $query = Product::query();
     if($s = request('search')){ $query->where('name','like',"%$s%"); }
@@ -34,9 +35,11 @@
     $navLinks = [
         ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
         ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
     ];
+    $cartSummary = Cart::summary();
 @endphp
-{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks])->render() !!}
+{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
 <section class="breadcrumb-section set-bg" data-setbg="{{ !empty($settings['hero.image']) ? asset('storage/'.$settings['hero.image']) : asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
     <div class="container">
         <div class="row">


### PR DESCRIPTION
## Summary
- add a session-backed cart helper and controller endpoints for browsing and mutating cart contents
- expose new "Keranjang" settings in the admin page manager and surface live cart counts inside each theme navigation
- build cart pages and asynchronous add-to-cart flows for Herbalgreen, Second, and Restoran themes with dynamic totals and empty states

## Testing
- php artisan test *(fails: composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfc3f8f9883299aeecc0eb5d45c49