### PR TITLE
Implement functional Midtrans and iPaymu payments

### DIFF
--- a/app/Http/Controllers/Admin/PaymentController.php
+++ b/app/Http/Controllers/Admin/PaymentController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\Payments\PaymentGatewayManager;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use Illuminate\Validation\Rule;
+
+class PaymentController extends Controller
+{
+    public function index(Request $request, PaymentGatewayManager $payments): View
+    {
+        $gateways = $payments->all();
+        $activeKey = $payments->getActiveKey();
+        $configs = $payments->getAllGatewayConfigs();
+
+        $methodSelections = [];
+        foreach ($gateways as $key => $gateway) {
+            $selected = $payments->getSelectedMethodKeys($key);
+            if (empty($selected)) {
+                $selected = $payments->getDefaultMethodKeys($gateway);
+            }
+            $methodSelections[$key] = $selected;
+        }
+
+        $defaultGateway = $activeKey ?? array_key_first($gateways);
+
+        return view('admin.payments.index', [
+            'gateways' => $gateways,
+            'activeGatewayKey' => $activeKey,
+            'configs' => $configs,
+            'methodSelections' => $methodSelections,
+            'defaultGatewayKey' => $defaultGateway,
+        ]);
+    }
+
+    public function update(Request $request, PaymentGatewayManager $payments): RedirectResponse
+    {
+        $gateways = $payments->all();
+        $gatewayKeys = array_keys($gateways);
+
+        if (empty($gatewayKeys)) {
+            return back()->withErrors(['gateway' => 'Tidak ada gateway pembayaran yang tersedia.']);
+        }
+
+        $baseRules = [
+            'gateway' => ['required', Rule::in($gatewayKeys)],
+        ];
+
+        $validated = $request->validate($baseRules);
+
+        $selectedGatewayKey = $validated['gateway'];
+        $gateway = $gateways[$selectedGatewayKey];
+
+        $methodKeys = array_keys($gateway->availableMethods());
+        $currentConfig = $payments->getGatewayConfig($selectedGatewayKey);
+        $methodRules = [
+            'methods' => ['required', 'array', 'min:1'],
+            'methods.*' => ['string', Rule::in($methodKeys)],
+        ];
+
+        $configRules = [];
+        foreach ($gateway->configFields() as $field) {
+            $rule = $field['rules'] ?? 'nullable';
+            $fieldKey = $field['key'];
+            $hasStoredValue = array_key_exists($fieldKey, $currentConfig) && $currentConfig[$fieldKey] !== null && $currentConfig[$fieldKey] !== '';
+            if ($hasStoredValue) {
+                $rule = str_replace('required', 'nullable', $rule);
+            }
+            $configRules['config.' . $fieldKey] = $rule;
+        }
+
+        $validated = $request->validate(array_merge($baseRules, $methodRules, $configRules));
+
+        $methods = $validated['methods'];
+        if (empty($methods)) {
+            $methods = $payments->getDefaultMethodKeys($gateway);
+        }
+
+        $configValues = [];
+        foreach ($gateway->configFields() as $field) {
+            $fieldKey = $field['key'];
+            $type = $field['type'] ?? 'text';
+            if (in_array($type, ['toggle', 'boolean', 'checkbox'], true)) {
+                $configValues[$fieldKey] = $request->boolean('config.' . $fieldKey);
+            } else {
+                $configValues[$fieldKey] = $validated['config'][$fieldKey] ?? ($currentConfig[$fieldKey] ?? null);
+            }
+        }
+
+        $payments->storeGateway($selectedGatewayKey);
+        $payments->storeMethods($selectedGatewayKey, $methods);
+        $payments->storeConfig($selectedGatewayKey, $configValues);
+
+        return redirect()->route('admin.payments.index')->with('success', 'Pengaturan pembayaran diperbarui.');
+    }
+}

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Setting;
+use App\Services\Payments\PaymentGatewayManager;
+use App\Support\Cart;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+
+class CheckoutController extends Controller
+{
+    public function payment(Request $request, PaymentGatewayManager $payments): View|RedirectResponse
+    {
+        $gateway = $payments->getActive();
+        if (! $gateway) {
+            abort(404, 'Gateway pembayaran belum dikonfigurasi.');
+        }
+
+        $cartSummary = Cart::summary();
+        if (empty($cartSummary['items'])) {
+            return redirect()->route('cart.index')->with('error', 'Keranjang Anda kosong.');
+        }
+
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+        $viewPath = base_path("themes/{$theme}/views/payment.blade.php");
+        if (! File::exists($viewPath)) {
+            abort(404);
+        }
+
+        $methods = $payments->getEnabledMethods($gateway->key());
+        if (empty($methods)) {
+            $available = $gateway->availableMethods();
+            foreach ($payments->getDefaultMethodKeys($gateway) as $methodKey) {
+                if (isset($available[$methodKey])) {
+                    $method = $available[$methodKey];
+                    $method['key'] = $methodKey;
+                    $methods[] = $method;
+                }
+            }
+        }
+
+        $config = $payments->getGatewayConfig($gateway->key());
+        $checkoutData = $gateway->checkoutData($config, $methods, $cartSummary);
+
+        $feedbackStatus = $this->resolveStatusMessage($request->query('status'));
+
+        return view()->file($viewPath, [
+            'theme' => $theme,
+            'gatewayKey' => $gateway->key(),
+            'gatewayLabel' => $gateway->label(),
+            'gatewayDescription' => $gateway->description(),
+            'cartSummary' => $cartSummary,
+            'methods' => $methods,
+            'checkoutData' => $checkoutData,
+            'selectedMethod' => $methods[0]['key'] ?? null,
+            'feedbackStatus' => $feedbackStatus,
+        ]);
+    }
+
+    public function createPaymentSession(Request $request, PaymentGatewayManager $payments): JsonResponse
+    {
+        $gateway = $payments->getActive();
+        if (! $gateway) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Gateway pembayaran belum dikonfigurasi.',
+            ], 422);
+        }
+
+        $data = $request->validate([
+            'payment_method' => ['required', 'string'],
+        ]);
+
+        $cartItems = Cart::items();
+        if (empty($cartItems)) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Keranjang Anda kosong.',
+            ], 422);
+        }
+
+        $methods = $payments->getEnabledMethods($gateway->key());
+        $selectedMethod = $payments->getEnabledMethod($data['payment_method'], $gateway->key());
+
+        if (! $selectedMethod) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Metode pembayaran tidak tersedia.',
+            ], 422);
+        }
+
+        $cart = [
+            'items' => $cartItems,
+            'total_price' => Cart::totalPrice(),
+        ];
+
+        $context = [
+            'selected_method' => $data['payment_method'],
+            'enabled_methods' => $methods,
+            'success_url' => route('checkout.payment', ['status' => 'success']),
+            'pending_url' => route('checkout.payment', ['status' => 'pending']),
+            'error_url' => route('checkout.payment', ['status' => 'failed']),
+            'cancel_url' => route('checkout.payment', ['status' => 'cancelled']),
+            'notify_url' => route('checkout.payment.webhook', ['gateway' => $gateway->key()]),
+        ];
+
+        if ($request->user()) {
+            $user = $request->user();
+            $context['customer'] = array_filter([
+                'first_name' => $user->name ?? null,
+                'email' => $user->email ?? null,
+                'phone' => $user->phone ?? null,
+            ]);
+        }
+
+        try {
+            $config = $payments->getGatewayConfig($gateway->key());
+            $session = $gateway->createPaymentSession($config, $cart, $context);
+        } catch (\Throwable $exception) {
+            Log::warning('Gagal membuat sesi pembayaran', [
+                'gateway' => $gateway->key(),
+                'message' => $exception->getMessage(),
+            ]);
+
+            return response()->json([
+                'status' => 'error',
+                'message' => $exception->getMessage() ?: 'Gagal memproses pembayaran.',
+            ], 422);
+        }
+
+        return response()->json([
+            'status' => 'ok',
+            'data' => $session,
+        ]);
+    }
+
+    public function webhook(Request $request, string $gateway): JsonResponse
+    {
+        Log::info('Notifikasi pembayaran diterima', [
+            'gateway' => $gateway,
+            'payload' => $request->all(),
+            'headers' => $request->headers->all(),
+        ]);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    protected function resolveStatusMessage(?string $status): ?array
+    {
+        if (! $status) {
+            return null;
+        }
+
+        $messages = [
+            'success' => ['message' => 'Pembayaran berhasil dikonfirmasi.', 'type' => 'success'],
+            'pending' => ['message' => 'Pembayaran Anda masih menunggu konfirmasi dari penyedia layanan.', 'type' => 'info'],
+            'failed' => ['message' => 'Pembayaran gagal diproses. Silakan coba kembali atau gunakan metode lain.', 'type' => 'error'],
+            'cancelled' => ['message' => 'Anda membatalkan proses pembayaran.', 'type' => 'info'],
+        ];
+
+        return $messages[$status] ?? null;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Services\Payments\PaymentGatewayManager;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +12,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(PaymentGatewayManager::class, function () {
+            return new PaymentGatewayManager();
+        });
     }
 
     /**

--- a/app/Services/Payments/Gateways/IpaymuGateway.php
+++ b/app/Services/Payments/Gateways/IpaymuGateway.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace App\Services\Payments\Gateways;
+
+use App\Services\Payments\PaymentGateway;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class IpaymuGateway implements PaymentGateway
+{
+    public function key(): string
+    {
+        return 'ipaymu';
+    }
+
+    public function label(): string
+    {
+        return 'iPaymu';
+    }
+
+    public function description(): string
+    {
+        return 'iPaymu menyediakan pembayaran virtual account, gerai retail, dan QRIS.';
+    }
+
+    public function configFields(): array
+    {
+        return [
+            [
+                'key' => 'va',
+                'label' => 'Virtual Account',
+                'type' => 'text',
+                'rules' => 'required|string',
+                'help' => 'Masukkan nomor virtual account merchant iPaymu Anda.',
+            ],
+            [
+                'key' => 'api_key',
+                'label' => 'API Key',
+                'type' => 'password',
+                'rules' => 'required|string',
+                'sensitive' => true,
+                'help' => 'Gunakan API key dari dashboard iPaymu.',
+            ],
+            [
+                'key' => 'sandbox',
+                'label' => 'Mode Sandbox',
+                'type' => 'toggle',
+                'default' => true,
+                'rules' => 'boolean',
+            ],
+        ];
+    }
+
+    public function availableMethods(): array
+    {
+        return [
+            'va' => [
+                'label' => 'Virtual Account',
+                'description' => 'Virtual account bank di jaringan iPaymu.',
+                'default' => true,
+                'ipaymu_code' => 'va',
+            ],
+            'qris' => [
+                'label' => 'QRIS',
+                'description' => 'Pembayaran menggunakan QRIS.',
+                'default' => true,
+                'ipaymu_code' => 'qris',
+            ],
+            'cstore' => [
+                'label' => 'Convenience Store',
+                'description' => 'Pembayaran melalui gerai Alfamart dan Indomaret.',
+                'ipaymu_code' => 'cstore',
+            ],
+        ];
+    }
+
+    public function checkoutData(array $config, array $selectedMethods, array $cartSummary): array
+    {
+        return [
+            'title' => 'Bayar melalui iPaymu',
+            'subtitle' => 'Gunakan iPaymu untuk menyelesaikan pembayaran Anda.',
+            'instructions' => [
+                'Tinjau kembali ringkasan pesanan di bawah ini.',
+                'Pilih metode pembayaran iPaymu yang tersedia.',
+                'Tekan tombol "Bayar via iPaymu" untuk membuat instruksi pembayaran.',
+            ],
+            'publicConfig' => [
+                'va' => $config['va'] ?? null,
+                'sandbox' => (bool) ($config['sandbox'] ?? false),
+                'supported_methods' => array_values(array_filter(array_map(
+                    fn (array $method) => $method['key'] ?? null,
+                    $selectedMethods
+                ))),
+            ],
+        ];
+    }
+
+    public function createPaymentSession(array $config, array $cart, array $context = []): array
+    {
+        $va = $config['va'] ?? null;
+        $apiKey = $config['api_key'] ?? null;
+
+        if (! $va || ! $apiKey) {
+            throw new RuntimeException('Konfigurasi iPaymu belum lengkap.');
+        }
+
+        $sandbox = ($config['sandbox'] ?? true) ? true : false;
+        $baseUrl = $sandbox ? 'https://sandbox.ipaymu.com' : 'https://my.ipaymu.com';
+
+        $items = Arr::get($cart, 'items', []);
+        if (empty($items)) {
+            throw new RuntimeException('Tidak ada item di keranjang.');
+        }
+
+        $products = [];
+        $quantities = [];
+        $prices = [];
+        $descriptions = [];
+        foreach ($items as $item) {
+            $name = (string) ($item['name'] ?? 'Produk');
+            $quantity = max(1, (int) ($item['quantity'] ?? 1));
+            $price = (int) ($item['price'] ?? 0);
+
+            $products[] = $name;
+            $quantities[] = (string) $quantity;
+            $prices[] = (string) $price;
+            $descriptions[] = $name;
+        }
+
+        $grossAmount = (int) ($cart['total_price'] ?? 0);
+        if ($grossAmount <= 0) {
+            $grossAmount = array_reduce($items, fn ($carry, $item) => $carry + ((int) ($item['price'] ?? 0) * max(1, (int) ($item['quantity'] ?? 1))), 0);
+        }
+
+        if ($grossAmount <= 0) {
+            throw new RuntimeException('Total belanja tidak valid.');
+        }
+
+        $selectedMethod = $context['selected_method'] ?? null;
+        $enabledMethods = $context['enabled_methods'] ?? [];
+        $methodCode = $this->resolveIpaymuMethod($enabledMethods, $selectedMethod);
+
+        $orderId = $context['reference'] ?? ('INV-' . now()->format('YmdHis') . '-' . Str::upper(Str::random(6)));
+
+        $body = [
+            'product' => $products,
+            'qty' => $quantities,
+            'price' => $prices,
+            'description' => $descriptions,
+            'returnUrl' => $context['success_url'] ?? route('checkout.payment', ['status' => 'success']),
+            'cancelUrl' => $context['cancel_url'] ?? route('checkout.payment', ['status' => 'cancelled']),
+            'notifyUrl' => $context['notify_url'] ?? route('checkout.payment.webhook', ['gateway' => $this->key()]),
+            'referenceId' => $orderId,
+            'amount' => (string) $grossAmount,
+        ];
+
+        if ($methodCode) {
+            $body['paymentMethod'] = $methodCode;
+        }
+
+        if (! empty($context['customer']) && is_array($context['customer'])) {
+            $body['buyerName'] = trim(($context['customer']['first_name'] ?? '') . ' ' . ($context['customer']['last_name'] ?? '')) ?: null;
+            $body['buyerEmail'] = $context['customer']['email'] ?? null;
+            $body['buyerPhone'] = $context['customer']['phone'] ?? null;
+        }
+
+        $jsonBody = json_encode($body, JSON_UNESCAPED_SLASHES);
+        if ($jsonBody === false) {
+            throw new RuntimeException('Gagal mempersiapkan data pembayaran iPaymu.');
+        }
+
+        $requestBody = strtolower(hash('sha256', $jsonBody));
+        $method = 'POST';
+        $stringToSign = strtoupper($method) . ':' . $va . ':' . $requestBody . ':' . $apiKey;
+        $signature = hash_hmac('sha256', $stringToSign, $apiKey);
+        $timestamp = now()->format('YmdHis');
+
+        try {
+            $response = Http::withHeaders([
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'va' => $va,
+                'signature' => $signature,
+                'timestamp' => $timestamp,
+            ])->post($baseUrl . '/api/v2/payment', $body);
+
+            if ($response->failed()) {
+                $message = $response->json('Message') ?? $response->json('message') ?? 'iPaymu mengembalikan respon yang tidak valid.';
+                throw new RuntimeException((string) $message);
+            }
+
+            $data = $response->json();
+            $url = Arr::get($data, 'Data.Url') ?? Arr::get($data, 'Data.PaymentUrl');
+
+            if (! $url) {
+                throw new RuntimeException('iPaymu tidak mengembalikan URL pembayaran.');
+            }
+
+            return [
+                'type' => 'redirect',
+                'redirect_url' => $url,
+                'reference' => $orderId,
+                'environment' => $sandbox ? 'sandbox' : 'production',
+            ];
+        } catch (RuntimeException $exception) {
+            throw $exception;
+        } catch (\Throwable $exception) {
+            Log::error('iPaymu checkout gagal', [
+                'message' => $exception->getMessage(),
+                'body' => $body,
+            ]);
+
+            throw new RuntimeException('Gagal membuat sesi pembayaran iPaymu.');
+        }
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $enabledMethods
+     */
+    protected function resolveIpaymuMethod(array $enabledMethods, ?string $selectedMethod): ?string
+    {
+        if ($selectedMethod) {
+            foreach ($enabledMethods as $method) {
+                if (($method['key'] ?? null) === $selectedMethod) {
+                    return $method['ipaymu_code'] ?? $method['key'];
+                }
+            }
+        }
+
+        foreach ($enabledMethods as $method) {
+            if (($method['default'] ?? false) === true) {
+                return $method['ipaymu_code'] ?? $method['key'] ?? null;
+            }
+        }
+
+        $first = reset($enabledMethods);
+
+        return is_array($first) ? ($first['ipaymu_code'] ?? $first['key'] ?? null) : null;
+    }
+}

--- a/app/Services/Payments/Gateways/MidtransGateway.php
+++ b/app/Services/Payments/Gateways/MidtransGateway.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace App\Services\Payments\Gateways;
+
+use App\Services\Payments\PaymentGateway;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class MidtransGateway implements PaymentGateway
+{
+    public function key(): string
+    {
+        return 'midtrans';
+    }
+
+    public function label(): string
+    {
+        return 'Midtrans';
+    }
+
+    public function description(): string
+    {
+        return 'Integrasi pembayaran Midtrans Snap dengan berbagai metode pembayaran populer.';
+    }
+
+    public function configFields(): array
+    {
+        return [
+            [
+                'key' => 'server_key',
+                'label' => 'Server Key',
+                'type' => 'password',
+                'rules' => 'required|string',
+                'sensitive' => true,
+                'help' => 'Ambil server key dari dashboard Midtrans Anda.',
+            ],
+            [
+                'key' => 'client_key',
+                'label' => 'Client Key',
+                'type' => 'text',
+                'rules' => 'required|string',
+                'help' => 'Client key diperlukan untuk memuat Snap di sisi front-end.',
+            ],
+            [
+                'key' => 'environment',
+                'label' => 'Mode Transaksi',
+                'type' => 'select',
+                'options' => [
+                    'sandbox' => 'Sandbox',
+                    'production' => 'Production',
+                ],
+                'default' => 'sandbox',
+                'rules' => 'required|in:sandbox,production',
+            ],
+        ];
+    }
+
+    public function availableMethods(): array
+    {
+        return [
+            'qris' => [
+                'label' => 'QRIS',
+                'description' => 'Pembayaran cepat melalui QRIS.',
+                'default' => true,
+                'snap_codes' => ['qris'],
+            ],
+            'bank_transfer' => [
+                'label' => 'Transfer Bank',
+                'description' => 'Virtual account bank seperti BCA, Mandiri, BNI, dan lainnya.',
+                'default' => true,
+                'snap_codes' => ['bank_transfer'],
+            ],
+            'credit_card' => [
+                'label' => 'Kartu Kredit/Debit',
+                'description' => 'Visa, Mastercard, JCB dan kartu lainnya.',
+                'snap_codes' => ['credit_card'],
+            ],
+            'gopay' => [
+                'label' => 'GoPay',
+                'description' => 'Dompet digital GoPay.',
+                'snap_codes' => ['gopay'],
+            ],
+        ];
+    }
+
+    public function checkoutData(array $config, array $selectedMethods, array $cartSummary): array
+    {
+        return [
+            'title' => 'Bayar dengan Midtrans',
+            'subtitle' => 'Midtrans Snap akan menangani proses pembayaran Anda.',
+            'instructions' => [
+                'Periksa kembali detail pesanan Anda di bawah ini.',
+                'Pilih metode pembayaran Midtrans yang ingin digunakan.',
+                'Klik tombol "Bayar dengan Midtrans" untuk membuka Snap dan selesaikan pembayaran.',
+            ],
+            'publicConfig' => [
+                'client_key' => $config['client_key'] ?? null,
+                'environment' => $config['environment'] ?? 'sandbox',
+                'supported_methods' => array_values(array_filter(array_map(
+                    fn (array $method) => $method['key'] ?? null,
+                    $selectedMethods
+                ))),
+            ],
+        ];
+    }
+
+    public function createPaymentSession(array $config, array $cart, array $context = []): array
+    {
+        $serverKey = $config['server_key'] ?? null;
+        if (! $serverKey) {
+            throw new RuntimeException('Midtrans server key belum dikonfigurasi.');
+        }
+
+        $environment = ($config['environment'] ?? 'sandbox') === 'production' ? 'production' : 'sandbox';
+        $baseUrl = $environment === 'production'
+            ? 'https://app.midtrans.com'
+            : 'https://app.sandbox.midtrans.com';
+
+        $items = [];
+        $rawItems = Arr::get($cart, 'items', []);
+        foreach ($rawItems as $index => $item) {
+            $quantity = max(1, (int) ($item['quantity'] ?? 1));
+            $price = (int) ($item['price'] ?? 0);
+            $items[] = [
+                'id' => (string) ($item['product_id'] ?? ('item-' . ($index + 1))),
+                'name' => substr((string) ($item['name'] ?? 'Item ' . ($index + 1)), 0, 50),
+                'price' => $price,
+                'quantity' => $quantity,
+            ];
+        }
+
+        if (empty($items)) {
+            throw new RuntimeException('Tidak ada item di keranjang.');
+        }
+
+        $grossAmount = (int) ($cart['total_price'] ?? 0);
+        if ($grossAmount <= 0) {
+            $grossAmount = array_reduce($items, fn ($carry, $item) => $carry + ($item['price'] * $item['quantity']), 0);
+        }
+
+        if ($grossAmount <= 0) {
+            throw new RuntimeException('Total belanja tidak valid.');
+        }
+
+        $selectedMethod = $context['selected_method'] ?? null;
+        $enabledMethods = $context['enabled_methods'] ?? [];
+        $enabledPayments = $this->resolveSnapPaymentCodes($enabledMethods, $selectedMethod);
+
+        $orderId = $context['reference'] ?? ('INV-' . now()->format('YmdHis') . '-' . Str::upper(Str::random(6)));
+
+        $payload = [
+            'transaction_details' => [
+                'order_id' => $orderId,
+                'gross_amount' => $grossAmount,
+            ],
+            'item_details' => $items,
+            'credit_card' => ['secure' => true],
+        ];
+
+        if (! empty($enabledPayments)) {
+            $payload['enabled_payments'] = $enabledPayments;
+        }
+
+        $callbacks = [
+            'finish' => $context['finish_url'] ?? $context['success_url'] ?? url('/checkout/payment'),
+            'error' => $context['error_url'] ?? url('/checkout/payment'),
+            'pending' => $context['pending_url'] ?? url('/checkout/payment'),
+        ];
+
+        $payload['callbacks'] = $callbacks;
+
+        if (! empty($context['customer']) && is_array($context['customer'])) {
+            $payload['customer_details'] = array_filter([
+                'first_name' => $context['customer']['first_name'] ?? null,
+                'last_name' => $context['customer']['last_name'] ?? null,
+                'email' => $context['customer']['email'] ?? null,
+                'phone' => $context['customer']['phone'] ?? null,
+            ]);
+        }
+
+        try {
+            $response = Http::withBasicAuth($serverKey, '')
+                ->acceptJson()
+                ->post($baseUrl . '/snap/v1/transactions', $payload);
+
+            if ($response->failed()) {
+                $message = $response->json('error_messages.0')
+                    ?? $response->json('status_message')
+                    ?? 'Midtrans mengembalikan respon yang tidak valid.';
+                throw new RuntimeException((string) $message);
+            }
+
+            $data = $response->json();
+            $redirectUrl = $data['redirect_url'] ?? null;
+            $token = $data['token'] ?? null;
+
+            if (! $redirectUrl || ! $token) {
+                throw new RuntimeException('Midtrans tidak mengembalikan tautan pembayaran.');
+            }
+
+            return [
+                'type' => 'redirect',
+                'redirect_url' => $redirectUrl,
+                'token' => $token,
+                'reference' => $orderId,
+                'environment' => $environment,
+            ];
+        } catch (RuntimeException $exception) {
+            throw $exception;
+        } catch (\Throwable $exception) {
+            Log::error('Midtrans checkout gagal', [
+                'message' => $exception->getMessage(),
+                'payload' => $payload,
+            ]);
+
+            throw new RuntimeException('Gagal membuat sesi pembayaran Midtrans.');
+        }
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $enabledMethods
+     * @return array<int, string>
+     */
+    protected function resolveSnapPaymentCodes(array $enabledMethods, ?string $selectedMethod): array
+    {
+        $candidates = [];
+
+        if ($selectedMethod) {
+            foreach ($enabledMethods as $method) {
+                if (($method['key'] ?? null) === $selectedMethod) {
+                    $candidates[] = $method;
+                    break;
+                }
+            }
+        }
+
+        if (empty($candidates)) {
+            $candidates = $enabledMethods;
+        }
+
+        $codes = [];
+        foreach ($candidates as $method) {
+            $snapCodes = $method['snap_codes'] ?? ($method['key'] ?? null);
+            if (is_array($snapCodes)) {
+                foreach ($snapCodes as $code) {
+                    if (is_string($code)) {
+                        $codes[] = $code;
+                    }
+                }
+            } elseif (is_string($snapCodes)) {
+                $codes[] = $snapCodes;
+            }
+        }
+
+        return array_values(array_unique(array_filter($codes)));
+    }
+}

--- a/app/Services/Payments/PaymentGateway.php
+++ b/app/Services/Payments/PaymentGateway.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services\Payments;
+
+interface PaymentGateway
+{
+    /**
+     * Unique identifier for the gateway.
+     */
+    public function key(): string;
+
+    /**
+     * Human readable name for the gateway.
+     */
+    public function label(): string;
+
+    /**
+     * Short description shown in the admin.
+     */
+    public function description(): string;
+
+    /**
+     * Configuration fields required for the gateway.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function configFields(): array;
+
+    /**
+     * Available payment methods supported by the gateway.
+     * The return value should be an associative array where the key is the method identifier.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function availableMethods(): array;
+
+    /**
+     * Data that should be shown on the checkout page when this gateway is active.
+     *
+     * @param  array<string, mixed>  $config
+     * @param  array<int, array<string, mixed>>  $selectedMethods
+     * @param  array<string, mixed>  $cartSummary
+     * @return array<string, mixed>
+     */
+    public function checkoutData(array $config, array $selectedMethods, array $cartSummary): array;
+
+    /**
+     * Create a hosted payment session and return the information required to redirect
+     * the customer to the gateway's default payment page.
+     *
+     * @param  array<string, mixed>  $config
+     * @param  array<string, mixed>  $cart
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function createPaymentSession(array $config, array $cart, array $context = []): array;
+}

--- a/app/Services/Payments/PaymentGatewayManager.php
+++ b/app/Services/Payments/PaymentGatewayManager.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace App\Services\Payments;
+
+use App\Models\Setting;
+use Illuminate\Support\Arr;
+
+class PaymentGatewayManager
+{
+    /**
+     * @var array<string, \App\Services\Payments\PaymentGateway>
+     */
+    protected array $gateways = [];
+
+    public function __construct()
+    {
+        $configured = config('payments.gateways', []);
+
+        foreach ($configured as $class) {
+            $instance = app($class);
+            if ($instance instanceof PaymentGateway) {
+                $this->gateways[$instance->key()] = $instance;
+            }
+        }
+    }
+
+    /**
+     * @return array<string, PaymentGateway>
+     */
+    public function all(): array
+    {
+        return $this->gateways;
+    }
+
+    public function get(string $key): ?PaymentGateway
+    {
+        return $this->gateways[$key] ?? null;
+    }
+
+    public function getActiveKey(): ?string
+    {
+        $key = Setting::getValue('payment.gateway');
+
+        return $key ?: null;
+    }
+
+    public function getActive(): ?PaymentGateway
+    {
+        $key = $this->getActiveKey();
+
+        return $key ? $this->get($key) : null;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getEnabledMethods(?string $gatewayKey = null): array
+    {
+        $gateway = $this->resolveGateway($gatewayKey);
+        if (! $gateway) {
+            return [];
+        }
+
+        $selected = $this->getSelectedMethodKeys($gateway->key());
+        $available = $gateway->availableMethods();
+
+        $methods = [];
+        foreach ($selected as $methodKey) {
+            if (! isset($available[$methodKey])) {
+                continue;
+            }
+
+            $method = $available[$methodKey];
+            $method['key'] = $methodKey;
+            $methods[] = $method;
+        }
+
+        return $methods;
+    }
+
+    public function getEnabledMethod(string $methodKey, ?string $gatewayKey = null): ?array
+    {
+        foreach ($this->getEnabledMethods($gatewayKey) as $method) {
+            if (($method['key'] ?? null) === $methodKey) {
+                return $method;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function getAllGatewayConfigs(): array
+    {
+        $configs = [];
+        foreach ($this->gateways as $key => $gateway) {
+            $configs[$key] = $this->getGatewayConfig($key);
+        }
+
+        return $configs;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getGatewayConfig(string $gatewayKey): array
+    {
+        $gateway = $this->get($gatewayKey);
+        if (! $gateway) {
+            return [];
+        }
+
+        $config = [];
+        foreach ($gateway->configFields() as $field) {
+            $fieldKey = $field['key'];
+            $default = $field['default'] ?? null;
+            $value = Setting::getValue($this->configKey($gatewayKey, $fieldKey), $default);
+
+            if ($this->isBooleanField($field)) {
+                $config[$fieldKey] = $this->castToBool($value, $default);
+            } else {
+                $config[$fieldKey] = $value;
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getSelectedMethodKeys(?string $gatewayKey = null): array
+    {
+        $gateway = $this->resolveGateway($gatewayKey);
+        if (! $gateway) {
+            return [];
+        }
+
+        $stored = Setting::getValue($this->methodsKey($gateway->key()), '[]');
+        $decoded = is_string($stored) ? json_decode($stored, true) : $stored;
+
+        if (is_array($decoded) && ! empty($decoded)) {
+            return array_values(array_filter($decoded, fn ($value) => is_string($value)));
+        }
+
+        return $this->getDefaultMethodKeys($gateway);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getDefaultMethodKeys(?PaymentGateway $gateway = null): array
+    {
+        $gateway ??= $this->getActive();
+        if (! $gateway) {
+            return [];
+        }
+
+        $methods = $gateway->availableMethods();
+        if (empty($methods)) {
+            return [];
+        }
+
+        $defaults = [];
+        foreach ($methods as $key => $method) {
+            if (Arr::get($method, 'default') === true) {
+                $defaults[] = $key;
+            }
+        }
+
+        if (! empty($defaults)) {
+            return $defaults;
+        }
+
+        return array_keys($methods);
+    }
+
+    public function storeGateway(string $gatewayKey): void
+    {
+        Setting::updateOrCreate(
+            ['key' => 'payment.gateway'],
+            ['value' => $gatewayKey]
+        );
+    }
+
+    public function storeMethods(string $gatewayKey, array $methods): void
+    {
+        Setting::updateOrCreate(
+            ['key' => $this->methodsKey($gatewayKey)],
+            ['value' => json_encode(array_values($methods))]
+        );
+    }
+
+    public function storeConfig(string $gatewayKey, array $values): void
+    {
+        $gateway = $this->get($gatewayKey);
+        if (! $gateway) {
+            return;
+        }
+
+        foreach ($gateway->configFields() as $field) {
+            $fieldKey = $field['key'];
+            $value = $values[$fieldKey] ?? ($field['default'] ?? null);
+
+            if ($this->isBooleanField($field)) {
+                $value = $value ? '1' : '0';
+            }
+
+            Setting::updateOrCreate(
+                ['key' => $this->configKey($gatewayKey, $fieldKey)],
+                ['value' => $value ?? '']
+            );
+        }
+    }
+
+    protected function resolveGateway(?string $gatewayKey = null): ?PaymentGateway
+    {
+        if ($gatewayKey) {
+            return $this->get($gatewayKey);
+        }
+
+        return $this->getActive();
+    }
+
+    protected function configKey(string $gatewayKey, string $fieldKey): string
+    {
+        return "payment.{$gatewayKey}.{$fieldKey}";
+    }
+
+    protected function methodsKey(string $gatewayKey): string
+    {
+        return "payment.methods.{$gatewayKey}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $field
+     */
+    protected function isBooleanField(array $field): bool
+    {
+        $type = $field['type'] ?? null;
+
+        return in_array($type, ['boolean', 'toggle', 'checkbox'], true);
+    }
+
+    protected function castToBool(mixed $value, mixed $default = null): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_null($value) && ! is_null($default)) {
+            return $this->castToBool($default);
+        }
+
+        return in_array((string) $value, ['1', 'true', 'on', 'yes'], true);
+    }
+}

--- a/config/payments.php
+++ b/config/payments.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'gateways' => [
+        \App\Services\Payments\Gateways\MidtransGateway::class,
+        \App\Services\Payments\Gateways\IpaymuGateway::class,
+    ],
+];

--- a/resources/views/admin/payments/index.blade.php
+++ b/resources/views/admin/payments/index.blade.php
@@ -1,0 +1,151 @@
+@extends('layout.admin')
+
+@section('content')
+  <div class="main-panel">
+    <div class="content-wrapper">
+      <div class="row">
+        <div class="col-12 grid-margin stretch-card">
+          <div class="card">
+            <div class="card-body">
+              <h4 class="card-title">Pengaturan Pembayaran</h4>
+              <p class="card-description mb-4">Pilih gateway pembayaran yang ingin digunakan dan lengkapi kredensial yang dibutuhkan.</p>
+
+              @if(session('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+              @endif
+
+              @if($errors->any())
+                <div class="alert alert-danger">
+                  <ul class="mb-0">
+                    @foreach($errors->all() as $error)
+                      <li>{{ $error }}</li>
+                    @endforeach
+                  </ul>
+                </div>
+              @endif
+
+              <form method="POST" action="{{ route('admin.payments.update') }}" id="payment-settings-form">
+                @csrf
+
+                <div class="form-group">
+                  <label for="gateway">Gateway Aktif</label>
+                  <select id="gateway" name="gateway" class="form-control">
+                    @foreach($gateways as $key => $gateway)
+                      <option value="{{ $key }}" {{ old('gateway', $activeGatewayKey ?? $defaultGatewayKey) === $key ? 'selected' : '' }}>
+                        {{ $gateway->label() }}
+                      </option>
+                    @endforeach
+                  </select>
+                </div>
+
+                @foreach($gateways as $key => $gateway)
+                  @php
+                    $sectionConfig = $configs[$key] ?? [];
+                    $selectedMethods = old('gateway') === $key ? (array) old('methods', []) : ($methodSelections[$key] ?? []);
+                    if(empty($selectedMethods) && !empty($methodSelections[$key] ?? [])) {
+                      $selectedMethods = $methodSelections[$key];
+                    }
+                  @endphp
+                  <div class="payment-gateway-section" data-gateway-section="{{ $key }}" style="display: none;">
+                    <div class="mb-4">
+                      <h5 class="font-weight-semibold mb-2">{{ $gateway->label() }}</h5>
+                      <p class="text-muted">{{ $gateway->description() }}</p>
+                    </div>
+
+                    <div class="form-group">
+                      <label class="d-block">Metode Pembayaran</label>
+                      <small class="form-text text-muted mb-2">Pilih metode yang ingin ditampilkan ke pelanggan.</small>
+                      <div class="row">
+                        @foreach($gateway->availableMethods() as $methodKey => $method)
+                          <div class="col-md-6">
+                            <div class="form-check form-check-info">
+                              <label class="form-check-label">
+                                <input type="checkbox" class="form-check-input" name="methods[]" value="{{ $methodKey }}" {{ in_array($methodKey, $selectedMethods, true) ? 'checked' : '' }}>
+                                <span class="font-weight-medium">{{ $method['label'] }}</span>
+                                <small class="d-block text-muted">{{ $method['description'] }}</small>
+                              </label>
+                            </div>
+                          </div>
+                        @endforeach
+                      </div>
+                    </div>
+
+                    <div class="row">
+                      @foreach($gateway->configFields() as $field)
+                        @php
+                          $fieldName = 'config[' . $field['key'] . ']';
+                          $inputId = $key . '_' . $field['key'];
+                          $value = old('gateway') === $key
+                            ? old('config.' . $field['key'], $sectionConfig[$field['key']] ?? null)
+                            : ($sectionConfig[$field['key']] ?? null);
+                        @endphp
+                        <div class="col-md-6">
+                          <div class="form-group">
+                            <label for="{{ $inputId }}">{{ $field['label'] }}</label>
+                            @if(($field['type'] ?? 'text') === 'select')
+                              <select name="{{ $fieldName }}" id="{{ $inputId }}" class="form-control">
+                                @foreach($field['options'] ?? [] as $optionValue => $optionLabel)
+                                  <option value="{{ $optionValue }}" {{ (string) $value === (string) $optionValue ? 'selected' : '' }}>{{ $optionLabel }}</option>
+                                @endforeach
+                              </select>
+                            @elseif(($field['type'] ?? 'text') === 'toggle')
+                              <div class="form-check form-switch">
+                                <input type="hidden" name="{{ $fieldName }}" value="0">
+                                <input type="checkbox" class="form-check-input" id="{{ $inputId }}" name="{{ $fieldName }}" value="1" {{ $value ? 'checked' : '' }}>
+                                <label class="form-check-label" for="{{ $inputId }}">{{ $field['label'] }}</label>
+                              </div>
+                            @else
+                              <input type="{{ $field['type'] ?? 'text' }}" class="form-control" id="{{ $inputId }}" name="{{ $fieldName }}" value="{{ $value }}" autocomplete="off">
+                            @endif
+                            @if(!empty($field['help']))
+                              <small class="form-text text-muted">{{ $field['help'] }}</small>
+                            @endif
+                          </div>
+                        </div>
+                      @endforeach
+                    </div>
+                  </div>
+                @endforeach
+
+                <div class="mt-4">
+                  <button type="submit" class="btn btn-primary">Simpan Pengaturan</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection
+
+@section('script')
+  <script>
+    (function() {
+      const select = document.getElementById('gateway');
+      const sections = document.querySelectorAll('[data-gateway-section]');
+
+      function toggleSections(active) {
+        sections.forEach(section => {
+          const isActive = section.getAttribute('data-gateway-section') === active;
+          section.style.display = isActive ? 'block' : 'none';
+          const inputs = section.querySelectorAll('input, select, textarea');
+          inputs.forEach(input => {
+            if (isActive) {
+              input.removeAttribute('disabled');
+            } else {
+              input.setAttribute('disabled', 'disabled');
+            }
+          });
+        });
+      }
+
+      if (select) {
+        select.addEventListener('change', function() {
+          toggleSections(this.value);
+        });
+        toggleSections(select.value);
+      }
+    })();
+  </script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,9 +8,11 @@ use App\Http\Controllers\ThemeAssetController;
 use App\Http\Controllers\CartController;
 use App\Http\Controllers\Admin\ThemeController;
 use App\Http\Controllers\Admin\TagController;
+use App\Http\Controllers\Admin\PaymentController;
 use App\Http\Controllers\Admin\ProductController;
 use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\PageController;
+use App\Http\Controllers\CheckoutController;
 
 /*
 |--------------------------------------------------------------------------
@@ -63,6 +65,10 @@ Route::get('/keranjang', [CartController::class, 'index'])->name('cart.index');
 Route::post('/cart/items', [CartController::class, 'store'])->name('cart.items.store');
 Route::patch('/cart/items/{product}', [CartController::class, 'update'])->name('cart.items.update');
 Route::delete('/cart/items/{product}', [CartController::class, 'destroy'])->name('cart.items.destroy');
+
+Route::get('/checkout/payment', [CheckoutController::class, 'payment'])->name('checkout.payment');
+Route::post('/checkout/payment/session', [CheckoutController::class, 'createPaymentSession'])->name('checkout.payment.session');
+Route::post('/checkout/payment/webhook/{gateway}', [CheckoutController::class, 'webhook'])->name('checkout.payment.webhook');
 
 Route::get('themes/{theme}/assets/{path}', ThemeAssetController::class)
     ->where('path', '.*')
@@ -117,4 +123,7 @@ Route::prefix('admin')/* ->middleware(['auth']) */->group(function () {
     Route::patch('pages/product-detail/comments/{comment}', [PageController::class, 'toggleComment'])->name('admin.pages.product-detail.comments.toggle');
     Route::get('pages/cart', [PageController::class, 'cart'])->name('admin.pages.cart');
     Route::post('pages/cart', [PageController::class, 'updateCart'])->name('admin.pages.cart.update');
+
+    Route::get('payments', [PaymentController::class, 'index'])->name('admin.payments.index');
+    Route::post('payments', [PaymentController::class, 'update'])->name('admin.payments.update');
 });

--- a/themes/theme-herbalgreen/views/cart.blade.php
+++ b/themes/theme-herbalgreen/views/cart.blade.php
@@ -255,6 +255,7 @@
         const csrf = '{{ csrf_token() }}';
         const updateUrl = '{{ route('cart.items.update', ['product' => '__ID__']) }}';
         const destroyUrl = '{{ route('cart.items.destroy', ['product' => '__ID__']) }}';
+        const paymentUrl = '{{ route('checkout.payment') }}';
         const cartBody = document.querySelector('[data-cart-body]');
         const cartContent = document.getElementById('cart-content');
         const emptyState = document.getElementById('cart-empty');
@@ -427,6 +428,15 @@
                     }
                     updateQuantity(row.dataset.productId, value);
                 }
+            });
+        }
+
+        if(actionButton){
+            actionButton.addEventListener('click', function(){
+                if(actionButton.disabled){
+                    return;
+                }
+                window.location.href = paymentUrl;
             });
         }
     })();

--- a/themes/theme-herbalgreen/views/payment.blade.php
+++ b/themes/theme-herbalgreen/views/payment.blade.php
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>{{ $checkoutData['title'] ?? 'Pembayaran' }}</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+    <style>
+        body {
+            background: #f4f9f4;
+        }
+        #payment {
+            padding: 4rem 2rem;
+            max-width: 1100px;
+            margin: 0 auto;
+        }
+        .payment-header {
+            text-align: center;
+            margin-bottom: 2.5rem;
+        }
+        .payment-header h1 {
+            font-size: 2.25rem;
+            margin-bottom: .75rem;
+        }
+        .payment-header p {
+            color: #52796f;
+            margin: 0;
+        }
+        .payment-layout {
+            display: grid;
+            grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+            gap: 2rem;
+        }
+        .card-box {
+            background: #fff;
+            border-radius: 18px;
+            box-shadow: 0 12px 30px rgba(0,0,0,0.08);
+            padding: 2rem;
+        }
+        .summary-items {
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+        }
+        .summary-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+        }
+        .summary-item h4 {
+            margin: 0 0 .25rem;
+            font-size: 1.1rem;
+        }
+        .summary-item span {
+            font-weight: 600;
+            color: var(--color-primary);
+        }
+        .summary-total {
+            margin-top: 2rem;
+            padding-top: 1.5rem;
+            border-top: 1px dashed #cbd5f0;
+            display: flex;
+            justify-content: space-between;
+            font-size: 1.25rem;
+            font-weight: 700;
+        }
+        .method-list {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+            gap: 1rem;
+            margin-bottom: 2rem;
+        }
+        .method-card {
+            display: flex;
+            align-items: flex-start;
+            gap: .75rem;
+            border: 1px solid #d8e2dc;
+            border-radius: 14px;
+            padding: 1rem;
+            cursor: pointer;
+            transition: border-color .2s ease, box-shadow .2s ease;
+        }
+        .method-card input {
+            margin-top: .2rem;
+        }
+        .method-card.active {
+            border-color: var(--color-primary);
+            box-shadow: 0 6px 18px rgba(53, 131, 116, 0.15);
+        }
+        .method-card small {
+            color: #6b9080;
+            display: block;
+        }
+        .payment-instructions {
+            margin-bottom: 2rem;
+        }
+        .payment-instructions h3 {
+            font-size: 1.15rem;
+            margin-bottom: .75rem;
+        }
+        .payment-instructions ol {
+            padding-left: 1.25rem;
+            color: #4a4a4a;
+        }
+        .payment-meta {
+            background: #f0fdf4;
+            border: 1px solid #bbf7d0;
+            padding: 1rem 1.25rem;
+            border-radius: 12px;
+            font-size: .95rem;
+            color: #166534;
+        }
+        .cta-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 999px;
+            padding: .95rem 2.75rem;
+            background: var(--color-primary);
+            color: #fff;
+            font-weight: 600;
+            border: none;
+            cursor: pointer;
+            transition: transform .2s ease;
+        }
+        .cta-button:hover {
+            transform: translateY(-1px);
+        }
+        .payment-feedback {
+            margin-top: 1rem;
+            min-height: 1.5rem;
+            font-weight: 500;
+            color: #d97706;
+        }
+        .payment-feedback.success {
+            color: #047857;
+        }
+        .payment-feedback.error {
+            color: #dc2626;
+        }
+        .payment-feedback.info {
+            color: #2563eb;
+        }
+        .back-link {
+            display: inline-flex;
+            align-items: center;
+            gap: .5rem;
+            margin-top: 1.5rem;
+            color: var(--color-secondary);
+            text-decoration: none;
+        }
+        @media (max-width: 992px) {
+            .payment-layout {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+@php
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
+    ];
+    $footerLinks = [
+        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => true],
+        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => true],
+    ];
+    $summaryItems = $cartSummary['items'] ?? [];
+    $instructions = $checkoutData['instructions'] ?? [];
+    $subtitle = $checkoutData['subtitle'] ?? 'Selesaikan pembayaran Anda dengan aman.';
+    $publicConfig = $checkoutData['publicConfig'] ?? [];
+    $selected = $selectedMethod ?? ($methods[0]['key'] ?? null);
+    $feedbackMessage = $feedbackStatus['message'] ?? null;
+    $feedbackType = $feedbackStatus['type'] ?? null;
+@endphp
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+
+<section id="payment">
+    <div class="payment-header">
+        <h1>{{ $checkoutData['title'] ?? 'Pembayaran' }}</h1>
+        <p>{{ $subtitle }}</p>
+    </div>
+    <div class="payment-layout">
+        <div class="card-box">
+            <h3 class="mb-3">Ringkasan Pesanan</h3>
+            <div class="summary-items">
+                @foreach($summaryItems as $item)
+                    <div class="summary-item">
+                        <div>
+                            <h4>{{ $item['name'] }}</h4>
+                            <small>x{{ $item['quantity'] }} • Rp {{ $item['price_formatted'] }}</small>
+                        </div>
+                        <span>Rp {{ $item['subtotal_formatted'] }}</span>
+                    </div>
+                @endforeach
+            </div>
+            <div class="summary-total">
+                <span>Total Pembayaran</span>
+                <span>Rp {{ $cartSummary['total_price_formatted'] ?? '0' }}</span>
+            </div>
+        </div>
+        <div class="card-box">
+            <h3 class="mb-3">Metode Pembayaran {{ $gatewayLabel }}</h3>
+            <div class="method-list" data-method-list>
+                @foreach($methods as $method)
+                    <label class="method-card {{ $selected === $method['key'] ? 'active' : '' }}" data-method-card data-method="{{ $method['key'] }}">
+                        <input type="radio" name="payment_method" value="{{ $method['key'] }}" {{ $selected === $method['key'] ? 'checked' : '' }}>
+                        <div>
+                            <strong>{{ $method['label'] }}</strong>
+                            <small>{{ $method['description'] }}</small>
+                        </div>
+                    </label>
+                @endforeach
+            </div>
+            <div class="payment-instructions">
+                <h3>Langkah Pembayaran</h3>
+                <ol>
+                    @forelse($instructions as $step)
+                        <li>{{ $step }}</li>
+                    @empty
+                        <li>Pilih metode pembayaran dan lanjutkan sesuai instruksi yang muncul.</li>
+                    @endforelse
+                </ol>
+            </div>
+            <div class="payment-meta mb-3">
+                <strong>Informasi Gateway:</strong>
+                <div>Gateway aktif: {{ ucfirst($gatewayKey) }}</div>
+                @if(!empty($publicConfig['environment']))
+                    <div>Mode: {{ ucfirst($publicConfig['environment']) }}</div>
+                @endif
+                @if(!empty($publicConfig['client_key']))
+                    <div>Client Key: {{ substr($publicConfig['client_key'], 0, 6) }}••••</div>
+                @endif
+                @if(!empty($publicConfig['va']))
+                    <div>Virtual Account: {{ $publicConfig['va'] }}</div>
+                @endif
+            </div>
+            <button class="cta-button" data-pay-button>Bayar dengan {{ $gatewayLabel }}</button>
+            <div class="payment-feedback {{ $feedbackType === 'success' ? 'success' : ($feedbackType === 'error' ? 'error' : ($feedbackType === 'info' ? 'info' : '')) }}" data-payment-feedback data-initial-message="{{ $feedbackMessage ?? '' }}" data-initial-type="{{ $feedbackType ?? '' }}">{{ $feedbackMessage }}</div>
+            <a href="{{ route('cart.index') }}" class="back-link">&larr; Kembali ke Keranjang</a>
+        </div>
+    </div>
+</section>
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
+    'links' => $footerLinks,
+    'copyright' => '© ' . date('Y') . ' Herbal Green'
+])->render() !!}
+
+<script>
+    (function(){
+        const methodCards = document.querySelectorAll('[data-method-card]');
+        const payButton = document.querySelector('[data-pay-button]');
+        const feedback = document.querySelector('[data-payment-feedback]');
+        const gateway = @json($gatewayKey);
+        const sessionEndpoint = @json(route('checkout.payment.session'));
+        const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+        const csrfToken = csrfMeta ? csrfMeta.getAttribute('content') : '';
+        const statusClasses = ['success', 'error', 'info'];
+
+        function setActive(card){
+            methodCards.forEach(item => item.classList.remove('active'));
+            card.classList.add('active');
+            const input = card.querySelector('input[type="radio"]');
+            if(input){
+                input.checked = true;
+            }
+        }
+
+        function setFeedback(message, type){
+            if(!feedback){
+                return;
+            }
+            feedback.textContent = message || '';
+            statusClasses.forEach(cls => feedback.classList.remove(cls));
+            if(type && statusClasses.includes(type)){
+                feedback.classList.add(type);
+            }
+        }
+
+        if(feedback){
+            const initialMessage = feedback.dataset.initialMessage || '';
+            const initialType = feedback.dataset.initialType || '';
+            if(initialMessage){
+                setFeedback(initialMessage, initialType);
+            }
+        }
+
+        methodCards.forEach(card => {
+            card.addEventListener('click', function(event){
+                if(event.target.matches('input')) return;
+                setActive(card);
+            });
+            const radio = card.querySelector('input[type="radio"]');
+            if(radio){
+                radio.addEventListener('change', () => setActive(card));
+            }
+        });
+
+        if(payButton){
+            payButton.dataset.originalText = payButton.textContent;
+            payButton.addEventListener('click', async function(){
+                const selected = document.querySelector('input[name="payment_method"]:checked');
+                if(!selected){
+                    setFeedback('Silakan pilih metode pembayaran terlebih dahulu.', 'error');
+                    return;
+                }
+
+                const headers = {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
+                };
+                if(csrfToken){
+                    headers['X-CSRF-TOKEN'] = csrfToken;
+                }
+
+                try {
+                    payButton.disabled = true;
+                    payButton.textContent = 'Memproses...';
+                    setFeedback('Mempersiapkan pembayaran ' + (gateway || '').toUpperCase() + '...', 'info');
+
+                    const response = await fetch(sessionEndpoint, {
+                        method: 'POST',
+                        headers,
+                        body: JSON.stringify({ payment_method: selected.value })
+                    });
+
+                    const payload = await response.json().catch(() => ({}));
+
+                    if(!response.ok || !payload || payload.status !== 'ok'){
+                        const message = (payload && payload.message) ? payload.message : 'Gagal memproses pembayaran.';
+                        throw new Error(message);
+                    }
+
+                    const data = payload.data || {};
+                    const redirectUrl = data.redirect_url || data.url || data.snap_url;
+
+                    if(redirectUrl){
+                        window.location.href = redirectUrl;
+                        return;
+                    }
+
+                    throw new Error('Gateway tidak mengembalikan tautan pembayaran.');
+                } catch (error) {
+                    setFeedback(error.message || 'Gagal memproses pembayaran.', 'error');
+                } finally {
+                    payButton.disabled = false;
+                    if(payButton.dataset.originalText){
+                        payButton.textContent = payButton.dataset.originalText;
+                    }
+                }
+            });
+        }
+    })();
+</script>
+</body>
+</html>

--- a/themes/theme-restoran/views/cart.blade.php
+++ b/themes/theme-restoran/views/cart.blade.php
@@ -211,6 +211,7 @@
         const csrf = '{{ csrf_token() }}';
         const updateUrl = '{{ route('cart.items.update', ['product' => '__ID__']) }}';
         const destroyUrl = '{{ route('cart.items.destroy', ['product' => '__ID__']) }}';
+        const paymentUrl = '{{ route('checkout.payment') }}';
         const cartBody = document.querySelector('[data-cart-body]');
         const cartContent = document.getElementById('cart-content');
         const emptyState = document.getElementById('cart-empty');
@@ -386,6 +387,15 @@
                     }
                     updateQuantity(row.dataset.productId, value);
                 }
+            });
+        }
+
+        if(actionButton){
+            actionButton.addEventListener('click', function(){
+                if(actionButton.disabled){
+                    return;
+                }
+                window.location.href = paymentUrl;
             });
         }
     })();

--- a/themes/theme-restoran/views/payment.blade.php
+++ b/themes/theme-restoran/views/payment.blade.php
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ $checkoutData['title'] ?? 'Pembayaran' }}</title>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <link href="{{ asset('storage/themes/theme-restoran/img/favicon.ico') }}" rel="icon">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600&family=Nunito:wght@600;700;800&family=Pacifico&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.0/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/animate/animate.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/assets/owl.carousel.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/css/tempusdominus-bootstrap-4.min.css') }}" rel="stylesheet" />
+    <link href="{{ asset('storage/themes/theme-restoran/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/css/style.css') }}" rel="stylesheet">
+    <style>
+        .payment-method-card {
+            border: 1px solid rgba(0,0,0,0.05);
+            border-radius: 16px;
+            padding: 1rem 1.25rem;
+            transition: all .2s ease;
+            cursor: pointer;
+        }
+        .payment-method-card.active {
+            border-color: var(--bs-primary);
+            box-shadow: 0 10px 25px rgba(0,0,0,0.08);
+        }
+        .payment-method-card input[type="radio"] {
+            margin-top: .3rem;
+        }
+        .payment-feedback {
+            min-height: 1.5rem;
+            font-weight: 600;
+        }
+        .payment-feedback.success {
+            color: #198754;
+        }
+        .payment-feedback.error {
+            color: #dc3545;
+        }
+        .payment-feedback.info {
+            color: #0d6efd;
+        }
+    </style>
+</head>
+<body>
+@php
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Menu', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
+    ];
+    $footerLinks = [
+        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => true],
+        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => true],
+    ];
+    $items = $cartSummary['items'] ?? [];
+    $instructions = $checkoutData['instructions'] ?? [];
+    $publicConfig = $checkoutData['publicConfig'] ?? [];
+    $selected = $selectedMethod ?? ($methods[0]['key'] ?? null);
+    $feedbackMessage = $feedbackStatus['message'] ?? null;
+    $feedbackType = $feedbackStatus['type'] ?? null;
+@endphp
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/navbar.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+
+<div class="container-xxl py-5">
+    <div class="container">
+        <div class="text-center mb-5">
+            <h1 class="display-5 mb-3">{{ $checkoutData['title'] ?? 'Pembayaran' }}</h1>
+            <p class="text-muted">{{ $checkoutData['subtitle'] ?? 'Selesaikan transaksi Anda dengan gateway pilihan.' }}</p>
+        </div>
+        <div class="row g-4">
+            <div class="col-lg-5">
+                <div class="bg-white rounded-3 shadow-lg p-4">
+                    <h4 class="mb-4">Ringkasan Pesanan</h4>
+                    <div class="list-group list-group-flush mb-4">
+                        @foreach($items as $item)
+                            <div class="list-group-item d-flex justify-content-between align-items-start px-0">
+                                <div>
+                                    <h6 class="mb-1">{{ $item['name'] }}</h6>
+                                    <small class="text-muted">x{{ $item['quantity'] }} • Rp {{ $item['price_formatted'] }}</small>
+                                </div>
+                                <span class="fw-semibold">Rp {{ $item['subtotal_formatted'] }}</span>
+                            </div>
+                        @endforeach
+                    </div>
+                    <div class="d-flex justify-content-between align-items-center border-top pt-3">
+                        <span class="fs-5 fw-semibold">Total</span>
+                        <span class="fs-4 fw-bold text-primary">Rp {{ $cartSummary['total_price_formatted'] ?? '0' }}</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-7">
+                <div class="bg-white rounded-3 shadow-lg p-4 h-100 d-flex flex-column">
+                    <div class="mb-4">
+                        <h4 class="mb-2">Metode Pembayaran {{ $gatewayLabel }}</h4>
+                        <p class="text-muted mb-0">Pilih metode pembayaran yang tersedia melalui {{ $gatewayLabel }}.</p>
+                    </div>
+                    <div class="row gy-3 mb-4" data-method-list>
+                        @foreach($methods as $method)
+                            <div class="col-md-6">
+                                <label class="payment-method-card w-100 {{ $selected === $method['key'] ? 'active' : '' }}" data-method-card data-method="{{ $method['key'] }}">
+                                    <div class="d-flex gap-3">
+                                        <input type="radio" name="payment_method" value="{{ $method['key'] }}" {{ $selected === $method['key'] ? 'checked' : '' }}>
+                                        <div>
+                                            <div class="fw-semibold">{{ $method['label'] }}</div>
+                                            <small class="text-muted">{{ $method['description'] }}</small>
+                                        </div>
+                                    </div>
+                                </label>
+                            </div>
+                        @endforeach
+                    </div>
+                    <div class="mb-4">
+                        <h5 class="mb-3">Langkah Pembayaran</h5>
+                        <ol class="text-muted">
+                            @forelse($instructions as $step)
+                                <li class="mb-2">{{ $step }}</li>
+                            @empty
+                                <li>Pilih metode pembayaran dan ikuti petunjuk yang diberikan.</li>
+                            @endforelse
+                        </ol>
+                    </div>
+                    <div class="alert alert-info d-flex flex-column gap-1">
+                        <div><strong>Gateway:</strong> {{ ucfirst($gatewayKey) }}</div>
+                        @if(!empty($publicConfig['environment']))
+                            <div><strong>Mode:</strong> {{ ucfirst($publicConfig['environment']) }}</div>
+                        @endif
+                        @if(!empty($publicConfig['client_key']))
+                            <div><strong>Client Key:</strong> {{ substr($publicConfig['client_key'], 0, 6) }}••••</div>
+                        @endif
+                        @if(!empty($publicConfig['va']))
+                            <div><strong>Virtual Account:</strong> {{ $publicConfig['va'] }}</div>
+                        @endif
+                    </div>
+                    <div class="mt-auto">
+                        <button class="btn btn-primary btn-lg w-100" data-pay-button>Bayar dengan {{ $gatewayLabel }}</button>
+                        <div class="payment-feedback mt-3 {{ $feedbackType === 'success' ? 'success' : ($feedbackType === 'error' ? 'error' : ($feedbackType === 'info' ? 'info' : '')) }}" data-payment-feedback data-initial-message="{{ $feedbackMessage ?? '' }}" data-initial-type="{{ $feedbackType ?? '' }}">{{ $feedbackMessage }}</div>
+                        <a href="{{ route('cart.index') }}" class="d-inline-flex align-items-center gap-2 mt-2 text-decoration-none">
+                            <i class="bi bi-arrow-left"></i>
+                            Kembali ke Keranjang
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), ['links' => $footerLinks])->render() !!}
+
+<script src="{{ asset('storage/themes/theme-restoran/js/bootstrap.bundle.min.js') }}"></script>
+<script>
+    (function(){
+        const methodCards = document.querySelectorAll('[data-method-card]');
+        const payButton = document.querySelector('[data-pay-button]');
+        const feedback = document.querySelector('[data-payment-feedback]');
+        const gateway = @json($gatewayKey);
+        const sessionEndpoint = @json(route('checkout.payment.session'));
+        const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+        const csrfToken = csrfMeta ? csrfMeta.getAttribute('content') : '';
+        const statusClasses = ['success', 'error', 'info'];
+
+        function activate(card){
+            methodCards.forEach(item => item.classList.remove('active'));
+            card.classList.add('active');
+            const input = card.querySelector('input[type="radio"]');
+            if(input){
+                input.checked = true;
+            }
+        }
+
+        function setFeedback(message, type){
+            if(!feedback){
+                return;
+            }
+            feedback.textContent = message || '';
+            statusClasses.forEach(cls => feedback.classList.remove(cls));
+            if(type && statusClasses.includes(type)){
+                feedback.classList.add(type);
+            }
+        }
+
+        if(feedback){
+            const initialMessage = feedback.dataset.initialMessage || '';
+            const initialType = feedback.dataset.initialType || '';
+            if(initialMessage){
+                setFeedback(initialMessage, initialType);
+            }
+        }
+
+        methodCards.forEach(card => {
+            card.addEventListener('click', function(event){
+                if(event.target.matches('input')) return;
+                activate(card);
+            });
+            const radio = card.querySelector('input[type="radio"]');
+            if(radio){
+                radio.addEventListener('change', () => activate(card));
+            }
+        });
+
+        if(payButton){
+            payButton.dataset.originalText = payButton.textContent;
+            payButton.addEventListener('click', async () => {
+                const selected = document.querySelector('input[name="payment_method"]:checked');
+                if(!selected){
+                    setFeedback('Pilih metode pembayaran terlebih dahulu.', 'error');
+                    return;
+                }
+
+                const headers = {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
+                };
+                if(csrfToken){
+                    headers['X-CSRF-TOKEN'] = csrfToken;
+                }
+
+                try {
+                    payButton.disabled = true;
+                    payButton.textContent = 'Memproses...';
+                    setFeedback('Mempersiapkan pembayaran ' + (gateway || '').toUpperCase() + '...', 'info');
+
+                    const response = await fetch(sessionEndpoint, {
+                        method: 'POST',
+                        headers,
+                        body: JSON.stringify({ payment_method: selected.value })
+                    });
+
+                    const payload = await response.json().catch(() => ({}));
+
+                    if(!response.ok || !payload || payload.status !== 'ok'){
+                        const message = (payload && payload.message) ? payload.message : 'Gagal memproses pembayaran.';
+                        throw new Error(message);
+                    }
+
+                    const data = payload.data || {};
+                    const redirectUrl = data.redirect_url || data.url || data.snap_url;
+
+                    if(redirectUrl){
+                        window.location.href = redirectUrl;
+                        return;
+                    }
+
+                    throw new Error('Gateway tidak mengembalikan tautan pembayaran.');
+                } catch (error) {
+                    setFeedback(error.message || 'Gagal memproses pembayaran.', 'error');
+                } finally {
+                    payButton.disabled = false;
+                    if(payButton.dataset.originalText){
+                        payButton.textContent = payButton.dataset.originalText;
+                    }
+                }
+            });
+        }
+    })();
+</script>
+</body>
+</html>

--- a/themes/theme-second/views/cart.blade.php
+++ b/themes/theme-second/views/cart.blade.php
@@ -241,6 +241,7 @@
         const csrf = '{{ csrf_token() }}';
         const updateUrl = '{{ route('cart.items.update', ['product' => '__ID__']) }}';
         const destroyUrl = '{{ route('cart.items.destroy', ['product' => '__ID__']) }}';
+        const paymentUrl = '{{ route('checkout.payment') }}';
         const cartBody = document.querySelector('[data-cart-body]');
         const cartContent = document.getElementById('cart-content');
         const emptyState = document.getElementById('cart-empty');
@@ -419,6 +420,15 @@
                     }
                     updateQuantity(row.dataset.productId, value);
                 }
+            });
+        }
+
+        if(actionButton){
+            actionButton.addEventListener('click', function(){
+                if(actionButton.disabled){
+                    return;
+                }
+                window.location.href = paymentUrl;
             });
         }
     })();

--- a/themes/theme-second/views/payment.blade.php
+++ b/themes/theme-second/views/payment.blade.php
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>{{ $checkoutData['title'] ?? 'Pembayaran' }}</title>
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/bootstrap.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/font-awesome.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/elegant-icons.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/nice-select.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/jquery-ui.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/owl.carousel.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/slicknav.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/style.css') }}" type="text/css">
+    <style>
+        body { background: #f8f9fa; }
+        .checkout__section { padding: 4rem 0; }
+        .checkout__box { background: #fff; border-radius: 12px; box-shadow: 0 15px 40px rgba(0,0,0,0.08); padding: 2rem; height: 100%; }
+        .checkout__box h4 { font-weight: 600; margin-bottom: 1.5rem; }
+        .summary__item { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 1.25rem; }
+        .summary__item h6 { margin: 0 0 .35rem; font-weight: 600; }
+        .summary__item span { font-weight: 600; color: #7fad39; }
+        .summary__total { border-top: 1px solid #f2f2f2; padding-top: 1.5rem; display: flex; justify-content: space-between; font-size: 1.25rem; font-weight: 700; }
+        .method__card { border: 1px solid #ececec; border-radius: 12px; padding: 1rem 1.25rem; display: flex; gap: .75rem; cursor: pointer; transition: all .2s ease; }
+        .method__card.active { border-color: #7fad39; box-shadow: 0 10px 25px rgba(127,173,57,0.25); }
+        .method__card input { margin-top: .3rem; }
+        .instructions__list { padding-left: 1.25rem; color: #666; }
+        .info__badge { background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 10px; padding: 1rem 1.25rem; font-size: .95rem; color: #166534; }
+        .btn-pay { background: #7fad39; border: none; border-radius: 999px; padding: .9rem 2.5rem; color: #fff; font-weight: 600; width: 100%; }
+        .btn-pay:hover { background: #6c9b30; }
+        .payment-feedback { min-height: 1.5rem; margin-top: 1rem; font-weight: 600; color: #6c757d; }
+        .payment-feedback.success { color: #7fad39; }
+        .payment-feedback.error { color: #d9534f; }
+        .payment-feedback.info { color: #0d6efd; }
+    </style>
+</head>
+<body>
+@php
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
+    ];
+    $footerLinks = [
+        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => true],
+        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => true],
+    ];
+    $items = $cartSummary['items'] ?? [];
+    $instructions = $checkoutData['instructions'] ?? [];
+    $publicConfig = $checkoutData['publicConfig'] ?? [];
+    $selected = $selectedMethod ?? ($methods[0]['key'] ?? null);
+    $feedbackMessage = $feedbackStatus['message'] ?? null;
+    $feedbackType = $feedbackStatus['type'] ?? null;
+@endphp
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+
+<section class="checkout__section">
+    <div class="container">
+        <div class="text-center mb-5">
+            <h2 class="fw-bold">{{ $checkoutData['title'] ?? 'Pembayaran' }}</h2>
+            <p class="text-muted">{{ $checkoutData['subtitle'] ?? 'Pilih metode pembayaran terbaik dan selesaikan pesanan Anda.' }}</p>
+        </div>
+        <div class="row g-4">
+            <div class="col-lg-5">
+                <div class="checkout__box">
+                    <h4>Ringkasan Pesanan</h4>
+                    @foreach($items as $item)
+                        <div class="summary__item">
+                            <div>
+                                <h6>{{ $item['name'] }}</h6>
+                                <small class="text-muted">x{{ $item['quantity'] }} • Rp {{ $item['price_formatted'] }}</small>
+                            </div>
+                            <span>Rp {{ $item['subtotal_formatted'] }}</span>
+                        </div>
+                    @endforeach
+                    <div class="summary__total">
+                        <span>Total Pembayaran</span>
+                        <span>Rp {{ $cartSummary['total_price_formatted'] ?? '0' }}</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-7">
+                <div class="checkout__box h-100 d-flex flex-column">
+                    <h4 class="mb-3">Metode Pembayaran {{ $gatewayLabel }}</h4>
+                    <div class="row g-3 mb-4" data-method-list>
+                        @foreach($methods as $method)
+                            <div class="col-md-6">
+                                <label class="method__card {{ $selected === $method['key'] ? 'active' : '' }}" data-method-card data-method="{{ $method['key'] }}">
+                                    <input type="radio" name="payment_method" value="{{ $method['key'] }}" {{ $selected === $method['key'] ? 'checked' : '' }}>
+                                    <div>
+                                        <div class="fw-semibold">{{ $method['label'] }}</div>
+                                        <small class="text-muted">{{ $method['description'] }}</small>
+                                    </div>
+                                </label>
+                            </div>
+                        @endforeach
+                    </div>
+                    <div class="mb-4">
+                        <h5>Langkah Pembayaran</h5>
+                        <ol class="instructions__list">
+                            @forelse($instructions as $step)
+                                <li class="mb-2">{{ $step }}</li>
+                            @empty
+                                <li>Pilih metode pembayaran dan ikuti panduan pada layar.</li>
+                            @endforelse
+                        </ol>
+                    </div>
+                    <div class="info__badge mb-4">
+                        <div><strong>Gateway:</strong> {{ ucfirst($gatewayKey) }}</div>
+                        @if(!empty($publicConfig['environment']))
+                            <div><strong>Mode:</strong> {{ ucfirst($publicConfig['environment']) }}</div>
+                        @endif
+                        @if(!empty($publicConfig['client_key']))
+                            <div><strong>Client Key:</strong> {{ substr($publicConfig['client_key'], 0, 6) }}••••</div>
+                        @endif
+                        @if(!empty($publicConfig['va']))
+                            <div><strong>Virtual Account:</strong> {{ $publicConfig['va'] }}</div>
+                        @endif
+                    </div>
+                    <div class="mt-auto">
+                        <button class="btn-pay" data-pay-button>Bayar dengan {{ $gatewayLabel }}</button>
+                        <div class="payment-feedback {{ $feedbackType === 'success' ? 'success' : ($feedbackType === 'error' ? 'error' : ($feedbackType === 'info' ? 'info' : '')) }}" data-payment-feedback data-initial-message="{{ $feedbackMessage ?? '' }}" data-initial-type="{{ $feedbackType ?? '' }}">{{ $feedbackMessage }}</div>
+                        <a href="{{ route('cart.index') }}" class="text-decoration-none text-muted">&larr; Kembali ke Keranjang</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), ['links' => $footerLinks])->render() !!}
+
+<script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>
+<script>
+    (function(){
+        const methodCards = document.querySelectorAll('[data-method-card]');
+        const payButton = document.querySelector('[data-pay-button]');
+        const feedback = document.querySelector('[data-payment-feedback]');
+        const gateway = @json($gatewayKey);
+        const sessionEndpoint = @json(route('checkout.payment.session'));
+        const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+        const csrfToken = csrfMeta ? csrfMeta.getAttribute('content') : '';
+        const statusClasses = ['success', 'error', 'info'];
+
+        function setActive(card){
+            methodCards.forEach(item => item.classList.remove('active'));
+            card.classList.add('active');
+            const input = card.querySelector('input[type="radio"]');
+            if(input){
+                input.checked = true;
+            }
+        }
+
+        function setFeedback(message, type){
+            if(!feedback){
+                return;
+            }
+            feedback.textContent = message || '';
+            statusClasses.forEach(cls => feedback.classList.remove(cls));
+            if(type && statusClasses.includes(type)){
+                feedback.classList.add(type);
+            }
+        }
+
+        if(feedback){
+            const initialMessage = feedback.dataset.initialMessage || '';
+            const initialType = feedback.dataset.initialType || '';
+            if(initialMessage){
+                setFeedback(initialMessage, initialType);
+            }
+        }
+
+        methodCards.forEach(card => {
+            card.addEventListener('click', function(event){
+                if(event.target.matches('input')) return;
+                setActive(card);
+            });
+            const radio = card.querySelector('input[type="radio"]');
+            if(radio){
+                radio.addEventListener('change', () => setActive(card));
+            }
+        });
+
+        if(payButton){
+            payButton.dataset.originalText = payButton.textContent;
+            payButton.addEventListener('click', async function(){
+                const selected = document.querySelector('input[name="payment_method"]:checked');
+                if(!selected){
+                    setFeedback('Pilih metode pembayaran terlebih dahulu.', 'error');
+                    return;
+                }
+
+                const headers = {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
+                };
+                if(csrfToken){
+                    headers['X-CSRF-TOKEN'] = csrfToken;
+                }
+
+                try {
+                    payButton.disabled = true;
+                    payButton.textContent = 'Memproses...';
+                    setFeedback('Membuka pembayaran ' + (gateway || '').toUpperCase() + '...', 'info');
+
+                    const response = await fetch(sessionEndpoint, {
+                        method: 'POST',
+                        headers,
+                        body: JSON.stringify({ payment_method: selected.value })
+                    });
+
+                    const payload = await response.json().catch(() => ({}));
+
+                    if(!response.ok || !payload || payload.status !== 'ok'){
+                        const message = (payload && payload.message) ? payload.message : 'Gagal memproses pembayaran.';
+                        throw new Error(message);
+                    }
+
+                    const data = payload.data || {};
+                    const redirectUrl = data.redirect_url || data.url || data.snap_url;
+
+                    if(redirectUrl){
+                        window.location.href = redirectUrl;
+                        return;
+                    }
+
+                    throw new Error('Gateway tidak mengembalikan tautan pembayaran.');
+                } catch (error) {
+                    setFeedback(error.message || 'Gagal memproses pembayaran.', 'error');
+                } finally {
+                    payButton.disabled = false;
+                    if(payButton.dataset.originalText){
+                        payButton.textContent = payButton.dataset.originalText;
+                    }
+                }
+            });
+        }
+    })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend the payment gateway contract and Midtrans driver to build Snap sessions and return the hosted redirect URL based on enabled methods
- add full iPaymu payment URL generation with the required signature headers and environment handling
- expose checkout endpoints for creating sessions and receiving callbacks, and update every theme payment page to post to the new API and redirect shoppers to the gateway

## Testing
- `php artisan test` *(fails: vendor/autoload.php is missing before dependencies are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4eb8e4688329a6804a5499364d42