### PR TITLE
Add order pages and admin order management

### DIFF
--- a/app/Http/Controllers/Admin/OrderController.php
+++ b/app/Http/Controllers/Admin/OrderController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use App\Models\Setting;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class OrderController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $shippingEnabled = Setting::getValue('shipping.enabled', '0') === '1';
+        $paymentEnabled = Setting::getValue('payment.gateway');
+
+        $orders = Order::with(['user', 'payment', 'shipping', 'items.product'])
+            ->latest()
+            ->paginate(15);
+
+        return view('admin.orders.index', [
+            'orders' => $orders,
+            'shippingEnabled' => $shippingEnabled,
+            'paymentEnabled' => ! empty($paymentEnabled),
+        ]);
+    }
+
+    public function toggleReview(Request $request, Order $order): RedirectResponse
+    {
+        if (Setting::getValue('shipping.enabled', '0') === '1') {
+            return back()->with('error', 'Status pesanan dikendalikan oleh pengiriman.');
+        }
+
+        $order->forceFill([
+            'is_reviewed' => ! $order->is_reviewed,
+        ])->save();
+
+        $message = $order->is_reviewed
+            ? 'Pesanan ditandai sudah diterima.'
+            : 'Pesanan ditandai belum diterima.';
+
+        return redirect()->route('admin.orders.index')->with('success', $message);
+    }
+}

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -2,7 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Address;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Payment;
 use App\Models\Setting;
+use App\Models\User;
 use App\Services\Payments\PaymentGatewayManager;
 use App\Support\Cart;
 use Illuminate\Http\JsonResponse;
@@ -10,6 +15,9 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 
 class CheckoutController extends Controller
@@ -94,34 +102,74 @@ class CheckoutController extends Controller
             ], 422);
         }
 
+        $cartSummary = Cart::summary();
         $cart = [
-            'items' => $cartItems,
-            'total_price' => Cart::totalPrice(),
+            'items' => $cartSummary['items'],
+            'total_price' => $cartSummary['total_price'],
         ];
 
-        $context = [
-            'selected_method' => $data['payment_method'],
-            'enabled_methods' => $methods,
-            'success_url' => route('checkout.payment', ['status' => 'success']),
-            'pending_url' => route('checkout.payment', ['status' => 'pending']),
-            'error_url' => route('checkout.payment', ['status' => 'failed']),
-            'cancel_url' => route('checkout.payment', ['status' => 'cancelled']),
-            'notify_url' => route('checkout.payment.webhook', ['gateway' => $gateway->key()]),
-        ];
-
-        if ($request->user()) {
-            $user = $request->user();
-            $context['customer'] = array_filter([
-                'first_name' => $user->name ?? null,
-                'email' => $user->email ?? null,
-                'phone' => $user->phone ?? null,
-            ]);
-        }
+        $orderNumber = 'ORD-' . now()->format('YmdHis') . '-' . Str::upper(Str::random(6));
+        $order = null;
 
         try {
+            DB::beginTransaction();
+
+            $user = $this->resolveCheckoutUser($request);
+            $address = $this->resolveCheckoutAddress($user);
+
+            $order = Order::create([
+                'user_id' => $user->getKey(),
+                'address_id' => $address->getKey(),
+                'order_number' => $orderNumber,
+                'status' => 'pending',
+                'total_price' => $cartSummary['total_price'],
+            ]);
+
+            foreach ($cartSummary['items'] as $item) {
+                $order->items()->create([
+                    'product_id' => $item['product_id'],
+                    'quantity' => $item['quantity'],
+                    'price' => $item['price'],
+                ]);
+            }
+
+            $paymentRecord = $order->payment()->create([
+                'method' => $this->determineStoredPaymentMethod($gateway->key(), $selectedMethod['key'] ?? $data['payment_method']),
+                'status' => 'pending',
+                'transaction_id' => $orderNumber,
+                'amount' => $cartSummary['total_price'],
+            ]);
+
+            $context = [
+                'selected_method' => $selectedMethod['key'] ?? $data['payment_method'],
+                'enabled_methods' => $methods,
+                'success_url' => route('orders.index', ['status' => 'success']),
+                'pending_url' => route('checkout.payment', ['status' => 'pending']),
+                'error_url' => route('checkout.payment', ['status' => 'failed']),
+                'cancel_url' => route('checkout.payment', ['status' => 'cancelled']),
+                'notify_url' => route('checkout.payment.webhook', ['gateway' => $gateway->key()]),
+                'reference' => $orderNumber,
+            ];
+
+            $customerContext = $this->buildCustomerContext($user, $address);
+            if (! empty($customerContext)) {
+                $context['customer'] = $customerContext;
+            }
+
             $config = $payments->getGatewayConfig($gateway->key());
             $session = $gateway->createPaymentSession($config, $cart, $context);
+
+            $reference = $session['reference'] ?? $orderNumber;
+            $transactionId = $session['transaction_id'] ?? ($session['token'] ?? $reference);
+
+            $paymentRecord->forceFill([
+                'transaction_id' => $transactionId,
+            ])->save();
+
+            DB::commit();
         } catch (\Throwable $exception) {
+            DB::rollBack();
+
             Log::warning('Gagal membuat sesi pembayaran', [
                 'gateway' => $gateway->key(),
                 'message' => $exception->getMessage(),
@@ -131,6 +179,10 @@ class CheckoutController extends Controller
                 'status' => 'error',
                 'message' => $exception->getMessage() ?: 'Gagal memproses pembayaran.',
             ], 422);
+        }
+
+        if ($order) {
+            $this->rememberOrderInSession($request, $order);
         }
 
         return response()->json([
@@ -147,7 +199,223 @@ class CheckoutController extends Controller
             'headers' => $request->headers->all(),
         ]);
 
+        $reference = $this->extractOrderReference($request);
+        $status = $this->extractPaymentStatus($request);
+
+        if ($reference) {
+            $payment = Payment::where('transaction_id', $reference)
+                ->orWhereHas('order', fn ($query) => $query->where('order_number', $reference))
+                ->first();
+
+            if ($payment) {
+                $this->updatePaymentStatus($payment, $status);
+            } else {
+                Log::warning('Pembayaran tidak ditemukan untuk notifikasi.', ['reference' => $reference]);
+            }
+        }
+
         return response()->json(['status' => 'ok']);
+    }
+
+    protected function resolveCheckoutUser(Request $request): User
+    {
+        if ($request->user()) {
+            return $request->user();
+        }
+
+        $email = (string) $request->input('customer.email', 'guest@local.test');
+        $name = (string) $request->input('customer.first_name', 'Guest Customer');
+
+        return User::firstOrCreate(
+            ['email' => $email],
+            [
+                'name' => $name,
+                'password' => Hash::make(Str::random(12)),
+            ]
+        );
+    }
+
+    protected function resolveCheckoutAddress(User $user): Address
+    {
+        $existing = $user->addresses()->first();
+        if ($existing) {
+            return $existing;
+        }
+
+        return $user->addresses()->create([
+            'recipient_name' => $user->name ?? 'Pelanggan',
+            'phone' => $user->phone ?? '0000000000',
+            'street' => 'Alamat belum diatur',
+            'village' => 'Belum diatur',
+            'subdistrict' => 'Belum diatur',
+            'city' => 'Belum diatur',
+            'province' => 'Belum diatur',
+            'postal_code' => '00000',
+            'is_default' => true,
+        ]);
+    }
+
+    protected function determineStoredPaymentMethod(string $gatewayKey, ?string $methodKey): string
+    {
+        $methodKey = strtolower($methodKey ?? '');
+
+        if ($gatewayKey === 'midtrans') {
+            return 'midtrans';
+        }
+
+        if (str_contains($methodKey, 'bank')) {
+            return 'bank_transfer';
+        }
+
+        if (in_array($methodKey, ['va', 'virtual_account', 'cstore'], true)) {
+            return 'bank_transfer';
+        }
+
+        return 'other';
+    }
+
+    protected function buildCustomerContext(User $user, Address $address): array
+    {
+        return array_filter([
+            'first_name' => $user->name ?? null,
+            'email' => $user->email ?? null,
+            'phone' => $user->phone ?? null,
+            'address' => $address->street ?? null,
+        ]);
+    }
+
+    protected function rememberOrderInSession(Request $request, Order $order): void
+    {
+        $ids = collect($request->session()->get('orders.recent', []))
+            ->filter(fn ($id) => is_numeric($id))
+            ->map(fn ($id) => (int) $id)
+            ->push($order->getKey())
+            ->unique()
+            ->take(20)
+            ->values()
+            ->all();
+
+        $request->session()->put('orders.recent', $ids);
+    }
+
+    protected function extractOrderReference(Request $request): ?string
+    {
+        $keys = [
+            'order_id',
+            'orderId',
+            'reference',
+            'reference_id',
+            'referenceId',
+            'transaction_id',
+            'transactionId',
+        ];
+
+        foreach ($keys as $key) {
+            if ($request->filled($key)) {
+                return (string) $request->input($key);
+            }
+        }
+
+        $data = $request->input('data');
+        if (is_array($data)) {
+            foreach ($keys as $key) {
+                if (! empty($data[$key])) {
+                    return (string) $data[$key];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected function extractPaymentStatus(Request $request): ?string
+    {
+        $keys = [
+            'transaction_status',
+            'transactionStatus',
+            'status',
+            'payment_status',
+            'paymentStatus',
+            'status_code',
+            'statusCode',
+            'Status',
+            'StatusCode',
+            'fraud_status',
+        ];
+
+        $candidates = [];
+
+        foreach ($keys as $key) {
+            if ($request->has($key)) {
+                $candidates[] = $request->input($key);
+            }
+        }
+
+        $data = $request->input('data');
+        if (is_array($data)) {
+            foreach ($keys as $key) {
+                if (array_key_exists($key, $data)) {
+                    $candidates[] = $data[$key];
+                }
+            }
+        }
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate)) {
+                continue;
+            }
+
+            $value = strtolower((string) $candidate);
+
+            if (in_array($value, ['capture', 'settlement', 'success', 'paid', 'completed', 'sukses', 'berhasil', '200'], true)) {
+                return 'success';
+            }
+
+            if (in_array($value, ['pending', 'challenge', 'waiting', 'in_process', 'process'], true)) {
+                return 'pending';
+            }
+
+            if (in_array($value, ['deny', 'failed', 'failure', 'cancel', 'cancelled', 'expire', 'expired', 'error', '404'], true)) {
+                return 'failed';
+            }
+        }
+
+        return null;
+    }
+
+    protected function updatePaymentStatus(Payment $payment, ?string $status): void
+    {
+        if (! $status) {
+            return;
+        }
+
+        $status = match ($status) {
+            'success' => 'success',
+            'failed' => 'failed',
+            default => 'pending',
+        };
+
+        $attributes = ['status' => $status];
+        if ($status === 'success') {
+            $attributes['paid_at'] = now();
+        } elseif ($status === 'failed') {
+            $attributes['paid_at'] = null;
+        }
+
+        $payment->forceFill($attributes)->save();
+
+        $order = $payment->order;
+        if (! $order) {
+            return;
+        }
+
+        if ($status === 'success' && $order->status !== 'paid') {
+            $order->forceFill(['status' => 'paid'])->save();
+        }
+
+        if ($status === 'failed' && $order->status === 'pending') {
+            $order->forceFill(['status' => 'cancelled'])->save();
+        }
     }
 
     protected function resolveStatusMessage(?string $status): ?array

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Order;
+use App\Models\Setting;
+use App\Services\Payments\PaymentGatewayManager;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+
+class OrderController extends Controller
+{
+    public function index(Request $request, PaymentGatewayManager $payments): View
+    {
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+        $viewPath = base_path("themes/{$theme}/views/order.blade.php");
+
+        if (! File::exists($viewPath)) {
+            Log::warning('Order view not found for theme.', ['theme' => $theme, 'path' => $viewPath]);
+            abort(404);
+        }
+
+        $shippingEnabled = Setting::getValue('shipping.enabled', '0') === '1';
+        $paymentEnabled = $payments->getActive() !== null;
+
+        $orderIds = collect($request->session()->get('orders.recent', []))
+            ->filter(fn ($id) => is_numeric($id))
+            ->map(fn ($id) => (int) $id)
+            ->unique()
+            ->values();
+
+        $ordersQuery = Order::query()
+            ->with([
+                'items.product.images',
+                'payment',
+                'shipping',
+            ])
+            ->latest();
+
+        $user = $request->user();
+
+        if ($user) {
+            $ordersQuery->where('user_id', $user->id);
+            if ($orderIds->isNotEmpty()) {
+                $ordersQuery->orWhereIn('id', $orderIds);
+            }
+        } elseif ($orderIds->isNotEmpty()) {
+            $ordersQuery->whereIn('id', $orderIds);
+        } else {
+            $ordersQuery->whereRaw('1 = 0');
+        }
+
+        $orders = $ordersQuery->get();
+
+        return view()->file($viewPath, [
+            'theme' => $theme,
+            'orders' => $orders,
+            'shippingEnabled' => $shippingEnabled,
+            'paymentEnabled' => $paymentEnabled,
+            'feedbackStatus' => $this->resolveStatusMessage($request->query('status')),
+        ]);
+    }
+
+    protected function resolveStatusMessage(?string $status): ?array
+    {
+        if (! $status) {
+            return null;
+        }
+
+        $messages = [
+            'success' => ['message' => 'Terima kasih! Pembayaran Anda sedang diverifikasi.', 'type' => 'success'],
+            'pending' => ['message' => 'Pembayaran masih menunggu konfirmasi.', 'type' => 'info'],
+            'failed' => ['message' => 'Pembayaran gagal diproses.', 'type' => 'error'],
+            'cancelled' => ['message' => 'Anda membatalkan proses pembayaran.', 'type' => 'info'],
+        ];
+
+        return $messages[$status] ?? null;
+    }
+}

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -11,7 +11,25 @@ class Address extends Model
 {
     use HasFactory;
 
-    public function user(): BelongsTo {
+    protected $fillable = [
+        'user_id',
+        'recipient_name',
+        'phone',
+        'street',
+        'village',
+        'subdistrict',
+        'city',
+        'province',
+        'postal_code',
+        'is_default',
+    ];
+
+    protected $casts = [
+        'is_default' => 'boolean',
+    ];
+
+    public function user(): BelongsTo
+    {
         return $this->belongsTo(User::class);
     }
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -17,23 +17,42 @@ class Order extends Model
 {
     use HasFactory;
 
-    public function user(): BelongsTo {
+    protected $fillable = [
+        'user_id',
+        'address_id',
+        'order_number',
+        'status',
+        'total_price',
+        'is_reviewed',
+    ];
+
+    protected $casts = [
+        'total_price' => 'float',
+        'is_reviewed' => 'boolean',
+    ];
+
+    public function user(): BelongsTo
+    {
         return $this->belongsTo(User::class);
     }
 
-    public function address(): BelongsTo {
+    public function address(): BelongsTo
+    {
         return $this->belongsTo(Address::class);
     }
 
-    public function items(): HasMany {
+    public function items(): HasMany
+    {
         return $this->hasMany(OrderItem::class);
     }
 
-    public function payment(): HasOne {
+    public function payment(): HasOne
+    {
         return $this->hasOne(Payment::class);
     }
 
-    public function shipping(): HasOne {
+    public function shipping(): HasOne
+    {
         return $this->hasOne(Shipping::class);
     }
 }

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -12,11 +12,25 @@ class OrderItem extends Model
 {
     use HasFactory;
 
-    public function order(): BelongsTo {
+    protected $fillable = [
+        'order_id',
+        'product_id',
+        'quantity',
+        'price',
+    ];
+
+    protected $casts = [
+        'quantity' => 'int',
+        'price' => 'float',
+    ];
+
+    public function order(): BelongsTo
+    {
         return $this->belongsTo(Order::class);
     }
 
-    public function product(): BelongsTo {
+    public function product(): BelongsTo
+    {
         return $this->belongsTo(Product::class);
     }
 }

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -11,7 +11,22 @@ class Payment extends Model
 {
     use HasFactory;
 
-    public function order(): BelongsTo {
+    protected $fillable = [
+        'order_id',
+        'method',
+        'status',
+        'transaction_id',
+        'amount',
+        'paid_at',
+    ];
+
+    protected $casts = [
+        'amount' => 'float',
+        'paid_at' => 'datetime',
+    ];
+
+    public function order(): BelongsTo
+    {
         return $this->belongsTo(Order::class);
     }
 }

--- a/app/Models/Shipping.php
+++ b/app/Models/Shipping.php
@@ -11,7 +11,22 @@ class Shipping extends Model
 {
     use HasFactory;
 
-    public function order(): BelongsTo {
+    protected $fillable = [
+        'order_id',
+        'courier',
+        'tracking_number',
+        'cost',
+        'status',
+        'estimated_delivery',
+    ];
+
+    protected $casts = [
+        'cost' => 'float',
+        'estimated_delivery' => 'date',
+    ];
+
+    public function order(): BelongsTo
+    {
         return $this->belongsTo(Order::class);
     }
 }

--- a/database/migrations/2025_09_23_231732_add_reviewed_flag_to_orders_table.php
+++ b/database/migrations/2025_09_23_231732_add_reviewed_flag_to_orders_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->boolean('is_reviewed')->default(false)->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn('is_reviewed');
+        });
+    }
+};

--- a/resources/views/admin/orders/index.blade.php
+++ b/resources/views/admin/orders/index.blade.php
@@ -1,0 +1,137 @@
+@extends('layout.admin')
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="page-header">
+      <h3 class="page-title">Pesanan</h3>
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="#">Transaksi</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Pesanan</li>
+        </ol>
+      </nav>
+    </div>
+
+    @if(session('success'))
+      <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+
+    @if(session('error'))
+      <div class="alert alert-danger">{{ session('error') }}</div>
+    @endif
+
+    <div class="row">
+      <div class="col-12 grid-margin stretch-card">
+        <div class="card">
+          <div class="card-body">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+              <div>
+                <h4 class="card-title mb-0">Daftar Pesanan</h4>
+                <small class="text-muted">Pantau status pembayaran dan pengiriman pelanggan Anda.</small>
+              </div>
+              <div class="text-right">
+                <span class="badge badge-outline-primary">Pembayaran: {{ $paymentEnabled ? 'Aktif' : 'Tidak Aktif' }}</span>
+                <span class="badge badge-outline-success ml-2">Pengiriman: {{ $shippingEnabled ? 'Aktif' : 'Tidak Aktif' }}</span>
+              </div>
+            </div>
+
+            <div class="table-responsive">
+              <table class="table table-hover">
+                <thead>
+                  <tr>
+                    <th>Nomor Pesanan</th>
+                    <th>Pelanggan</th>
+                    <th>Total</th>
+                    <th>Pembayaran</th>
+                    <th>Status</th>
+                    <th>Ringkasan</th>
+                    <th>Dibuat</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @forelse($orders as $order)
+                    <tr>
+                      <td>
+                        <strong>{{ $order->order_number }}</strong>
+                        <div class="small text-muted">#{{ $order->id }}</div>
+                      </td>
+                      <td>
+                        <div class="font-weight-semibold">{{ $order->user->name ?? 'Pengguna' }}</div>
+                        <div class="small text-muted">{{ $order->user->email ?? '-' }}</div>
+                      </td>
+                      <td>Rp {{ number_format($order->total_price ?? 0, 0, ',', '.') }}</td>
+                      <td>
+                        @php
+                          $payment = $order->payment;
+                          $status = optional($payment)->status ?? 'pending';
+                          $statusLabel = [
+                            'pending' => 'badge-warning',
+                            'success' => 'badge-success',
+                            'failed' => 'badge-danger',
+                          ][$status] ?? 'badge-secondary';
+                        @endphp
+                        @if($payment)
+                          <div class="badge {{ $statusLabel }} text-uppercase mb-1">{{ $payment->status }}</div>
+                          <div class="small">Metode: {{ strtoupper($payment->method) }}</div>
+                          <div class="small">Transaksi: {{ $payment->transaction_id ?? '-' }}</div>
+                        @else
+                          <span class="badge badge-secondary">Belum ada</span>
+                        @endif
+                      </td>
+                      <td>
+                        @if($shippingEnabled)
+                          @php
+                            $shippingStatus = optional($order->shipping)->status ?? 'packing';
+                            $shippingLabel = [
+                              'packing' => 'badge-info',
+                              'in_transit' => 'badge-warning',
+                              'delivered' => 'badge-success',
+                            ][$shippingStatus] ?? 'badge-secondary';
+                          @endphp
+                          <span class="badge {{ $shippingLabel }} text-capitalize">{{ str_replace('_', ' ', $shippingStatus) }}</span>
+                        @else
+                          <form method="POST" action="{{ route('admin.orders.review', $order) }}">
+                            @csrf
+                            @method('PATCH')
+                            <button type="submit" class="btn btn-sm {{ $order->is_reviewed ? 'btn-success' : 'btn-outline-secondary' }}">
+                              {{ $order->is_reviewed ? 'Diterima' : 'Belum' }}
+                            </button>
+                          </form>
+                        @endif
+                      </td>
+                      <td style="max-width: 240px;">
+                        <ul class="pl-3 mb-0 small">
+                          @foreach($order->items as $item)
+                            <li>{{ $item->product->name ?? 'Produk' }} ({{ $item->quantity }}x)</li>
+                          @endforeach
+                        </ul>
+                      </td>
+                      <td>
+                        <div>{{ $order->created_at?->format('d M Y') }}</div>
+                        <div class="small text-muted">{{ $order->created_at?->format('H:i') }}</div>
+                      </td>
+                    </tr>
+                  @empty
+                    <tr>
+                      <td colspan="7" class="text-center">Belum ada pesanan.</td>
+                    </tr>
+                  @endforelse
+                </tbody>
+              </table>
+            </div>
+
+            <div class="d-flex justify-content-between align-items-center mt-3">
+              <div>
+                <small class="text-muted">Menampilkan {{ $orders->firstItem() ?? 0 }} - {{ $orders->lastItem() ?? 0 }} dari {{ $orders->total() ?? 0 }} pesanan</small>
+              </div>
+              <div>
+                {{ $orders->appends(request()->query())->links() }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -71,7 +71,7 @@
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="{{url('/admin/order')}}">
+            <a class="nav-link" href="{{ route('admin.orders.index') }}">
               <i class="mdi mdi-receipt menu-icon"></i>
               <span class="menu-title">Pesanan</span>
             </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,8 @@ use App\Http\Controllers\Admin\ProductController;
 use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\PageController;
 use App\Http\Controllers\CheckoutController;
+use App\Http\Controllers\OrderController;
+use App\Http\Controllers\Admin\OrderController as AdminOrderController;
 
 /*
 |--------------------------------------------------------------------------
@@ -65,6 +67,8 @@ Route::get('/keranjang', [CartController::class, 'index'])->name('cart.index');
 Route::post('/cart/items', [CartController::class, 'store'])->name('cart.items.store');
 Route::patch('/cart/items/{product}', [CartController::class, 'update'])->name('cart.items.update');
 Route::delete('/cart/items/{product}', [CartController::class, 'destroy'])->name('cart.items.destroy');
+
+Route::get('/pesanan', [OrderController::class, 'index'])->name('orders.index');
 
 Route::get('/checkout/payment', [CheckoutController::class, 'payment'])->name('checkout.payment');
 Route::post('/checkout/payment/session', [CheckoutController::class, 'createPaymentSession'])->name('checkout.payment.session');
@@ -123,6 +127,9 @@ Route::prefix('admin')/* ->middleware(['auth']) */->group(function () {
     Route::patch('pages/product-detail/comments/{comment}', [PageController::class, 'toggleComment'])->name('admin.pages.product-detail.comments.toggle');
     Route::get('pages/cart', [PageController::class, 'cart'])->name('admin.pages.cart');
     Route::post('pages/cart', [PageController::class, 'updateCart'])->name('admin.pages.cart.update');
+
+    Route::get('order', [AdminOrderController::class, 'index'])->name('admin.orders.index');
+    Route::patch('order/{order}/review', [AdminOrderController::class, 'toggleReview'])->name('admin.orders.review');
 
     Route::get('payments', [PaymentController::class, 'index'])->name('admin.payments.index');
     Route::post('payments', [PaymentController::class, 'update'])->name('admin.payments.update');

--- a/themes/theme-herbalgreen/views/order.blade.php
+++ b/themes/theme-herbalgreen/views/order.blade.php
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pesanan</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+    <style>
+        #orders {
+            padding: 4rem 2rem;
+            background: #f7f7f7;
+        }
+        #orders h1 {
+            text-align: center;
+            margin-bottom: 0.5rem;
+        }
+        #orders p.subtitle {
+            text-align: center;
+            color: #4a4a4a;
+            margin-bottom: 2.5rem;
+        }
+        .feedback-banner {
+            margin: 0 auto 2rem;
+            max-width: 920px;
+            padding: 1rem 1.25rem;
+            border-radius: 12px;
+            font-weight: 600;
+        }
+        .feedback-banner.success { background: rgba(76,175,80,0.12); color: #2e7d32; }
+        .feedback-banner.info { background: rgba(33,150,243,0.12); color: #1e88e5; }
+        .feedback-banner.error { background: rgba(244,67,54,0.12); color: #c62828; }
+        .order-wrapper {
+            max-width: 1100px;
+            margin: 0 auto 2rem;
+            background: #fff;
+            border-radius: 16px;
+            box-shadow: 0 12px 35px rgba(15,23,42,0.08);
+            padding: 2rem;
+        }
+        .order-header {
+            display: flex;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+        .order-header h2 {
+            margin: 0;
+            font-size: 1.4rem;
+            color: var(--color-primary);
+        }
+        .order-meta {
+            font-size: 0.95rem;
+            color: #6f6f6f;
+        }
+        .order-status {
+            display: inline-flex;
+            align-items: center;
+            padding: 0.4rem 0.75rem;
+            border-radius: 999px;
+            font-weight: 600;
+            font-size: 0.85rem;
+        }
+        .order-status.success { background: rgba(76,175,80,0.15); color: #2e7d32; }
+        .order-status.warning { background: rgba(255,193,7,0.15); color: #c28704; }
+        .order-status.info { background: rgba(33,150,243,0.12); color: #1e88e5; }
+        .order-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .order-table thead {
+            background: var(--color-primary);
+            color: #fff;
+        }
+        .order-table th,
+        .order-table td {
+            padding: 1rem 1.2rem;
+            text-align: left;
+        }
+        .order-table tbody tr:nth-child(even) {
+            background: #fafafa;
+        }
+        .order-item {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+        .order-item img {
+            width: 70px;
+            height: 70px;
+            object-fit: cover;
+            border-radius: 12px;
+        }
+        .order-summary {
+            display: flex;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 1rem;
+            margin-top: 1.5rem;
+            padding-top: 1rem;
+            border-top: 1px solid #e5e7eb;
+        }
+        .order-empty {
+            text-align: center;
+            max-width: 700px;
+            margin: 0 auto;
+            background: #fff;
+            padding: 3rem 2rem;
+            border-radius: 16px;
+            box-shadow: 0 12px 35px rgba(15,23,42,0.08);
+        }
+        .order-empty a {
+            display: inline-block;
+            margin-top: 1.5rem;
+            background: var(--color-primary);
+            color: #fff;
+            padding: 0.8rem 1.6rem;
+            border-radius: 999px;
+            text-decoration: none;
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+@php
+    $orders = $orders ?? collect();
+    $feedbackStatus = $feedbackStatus ?? null;
+    $cartSummary = App\Support\Cart::summary();
+    $links = [
+        ['label' => 'Home', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
+        ['label' => 'Pesanan', 'href' => url('/pesanan'), 'visible' => true],
+    ];
+@endphp
+
+{!! view()->file(base_path('themes/theme-herbalgreen/views/components/nav-menu.blade.php'), ['links' => $links, 'cart' => $cartSummary])->render() !!}
+
+<section id="orders">
+    <h1>Pesanan</h1>
+    <p class="subtitle">Pantau status pesanan dan pembayaran Anda.</p>
+
+    @if($feedbackStatus)
+        <div class="feedback-banner {{ $feedbackStatus['type'] ?? 'info' }}">
+            {{ $feedbackStatus['message'] ?? '' }}
+        </div>
+    @endif
+
+    @if($orders->isEmpty())
+        <div class="order-empty">
+            <h3>Belum ada pesanan</h3>
+            <p>Segera lengkapi proses checkout untuk melihat pesanan Anda di sini.</p>
+            <a href="{{ url('/produk') }}">Belanja Sekarang</a>
+        </div>
+    @else
+        @foreach($orders as $order)
+            @php
+                $shippingStatus = optional($order->shipping)->status ?? 'packing';
+                $statusLabel = 'Menunggu Konfirmasi';
+                $statusClass = 'info';
+                if($shippingEnabled) {
+                    $statusLabel = match($shippingStatus) {
+                        'delivered' => 'Pesanan Terkirim',
+                        'in_transit' => 'Dalam Pengiriman',
+                        default => 'Sedang Diproses',
+                    };
+                    $statusClass = match($shippingStatus) {
+                        'delivered' => 'success',
+                        'in_transit' => 'warning',
+                        default => 'info',
+                    };
+                } else {
+                    $statusLabel = $order->is_reviewed ? 'Sudah dikonfirmasi admin' : 'Belum dikonfirmasi admin';
+                    $statusClass = $order->is_reviewed ? 'success' : 'warning';
+                }
+                $orderStatus = $order->status === 'paid' ? 'Pembayaran diterima' : ucfirst($order->status);
+            @endphp
+            <div class="order-wrapper">
+                <div class="order-header">
+                    <div>
+                        <h2>Pesanan #{{ $order->order_number }}</h2>
+                        <div class="order-meta">Dibuat pada {{ $order->created_at?->format('d M Y H:i') }}</div>
+                    </div>
+                    <div class="text-right">
+                        <div class="order-meta">Status Pembayaran: {{ $orderStatus }}</div>
+                        <span class="order-status {{ $statusClass }}">{{ $statusLabel }}</span>
+                    </div>
+                </div>
+
+                <table class="order-table">
+                    <thead>
+                        <tr>
+                            <th>Produk</th>
+                            <th>Harga</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($order->items as $item)
+                            @php
+                                $product = $item->product;
+                                $imagePath = optional($product?->images?->first())->path;
+                                $imageUrl = $imagePath ? asset('storage/' . $imagePath) : 'https://via.placeholder.com/120x120?text=No+Image';
+                                $productUrl = $product ? route('products.show', $product->id) : '#';
+                                $subtotal = (int) $item->price * (int) $item->quantity;
+                            @endphp
+                            <tr>
+                                <td>
+                                    <div class="order-item">
+                                        <img src="{{ $imageUrl }}" alt="{{ $product->name ?? 'Produk' }}">
+                                        <div>
+                                            <a href="{{ $productUrl }}" class="text-bold" style="color: var(--color-primary);">{{ $product->name ?? 'Produk' }}</a>
+                                            <div class="order-meta">{{ $item->quantity }} x Rp {{ number_format($item->price ?? 0, 0, ',', '.') }}</div>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td>Rp {{ number_format($subtotal, 0, ',', '.') }}</td>
+                                <td>
+                                    <span class="order-status {{ $statusClass }}">{{ $statusLabel }}</span>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+
+                <div class="order-summary">
+                    <div class="order-meta">Total Produk: {{ $order->items->sum('quantity') }}</div>
+                    <div class="order-meta">Total Pembayaran: <strong>Rp {{ number_format($order->total_price ?? 0, 0, ',', '.') }}</strong></div>
+                </div>
+            </div>
+        @endforeach
+    @endif
+</section>
+
+{!! view()->file(base_path('themes/theme-herbalgreen/views/components/footer.blade.php'))->render() !!}
+</body>
+</html>

--- a/themes/theme-restoran/views/order.blade.php
+++ b/themes/theme-restoran/views/order.blade.php
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Pesanan</title>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <link href="{{ asset('storage/themes/theme-restoran/img/favicon.ico') }}" rel="icon">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600&family=Nunito:wght@600;700;800&family=Pacifico&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.0/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/animate/animate.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/assets/owl.carousel.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/css/tempusdominus-bootstrap-4.min.css') }}" rel="stylesheet" />
+    <link href="{{ asset('storage/themes/theme-restoran/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/css/style.css') }}" rel="stylesheet">
+    <style>
+        .hero-header {
+            padding: 6rem 0 4rem;
+        }
+        .order-section {
+            padding: 4rem 0;
+        }
+        .order-card {
+            background: #fff;
+            border-radius: 16px;
+            box-shadow: 0 15px 40px rgba(15, 23, 42, 0.12);
+            padding: 2.5rem;
+            margin-bottom: 2.5rem;
+        }
+        .order-card h2 {
+            font-size: 1.5rem;
+            margin-bottom: 0.25rem;
+        }
+        .order-card p {
+            margin-bottom: 0;
+        }
+        .status-pill {
+            display: inline-flex;
+            align-items: center;
+            padding: 0.45rem 0.9rem;
+            border-radius: 999px;
+            font-weight: 600;
+            font-size: 0.9rem;
+        }
+        .status-pill.success { background: rgba(25, 135, 84, 0.12); color: #198754; }
+        .status-pill.warning { background: rgba(255, 193, 7, 0.15); color: #ff9800; }
+        .status-pill.info { background: rgba(13, 110, 253, 0.12); color: #0d6efd; }
+        .order-table { width: 100%; }
+        .order-table thead {
+            background: var(--bs-dark);
+            color: #fff;
+        }
+        .order-table th,
+        .order-table td {
+            padding: 1.1rem 1rem;
+            vertical-align: middle;
+        }
+        .order-item {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+        .order-item img {
+            width: 78px;
+            height: 78px;
+            border-radius: 12px;
+            object-fit: cover;
+        }
+        .feedback-alert {
+            padding: 1.1rem 1.3rem;
+            border-radius: 12px;
+            font-weight: 600;
+            margin-bottom: 2rem;
+        }
+        .feedback-alert.success { background: rgba(25, 135, 84, 0.12); color: #198754; }
+        .feedback-alert.info { background: rgba(13, 110, 253, 0.12); color: #0d6efd; }
+        .feedback-alert.error { background: rgba(220, 53, 69, 0.12); color: #dc3545; }
+        .order-empty {
+            text-align: center;
+            padding: 3rem 1.5rem;
+            background: #fff;
+            border-radius: 16px;
+            box-shadow: 0 15px 40px rgba(15,23,42,0.1);
+        }
+        .order-empty a {
+            display: inline-block;
+            margin-top: 1.5rem;
+            padding: 0.8rem 1.8rem;
+            border-radius: 999px;
+            background: var(--bs-primary);
+            color: #fff;
+            text-decoration: none;
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+@php
+    $orders = $orders ?? collect();
+    $feedbackStatus = $feedbackStatus ?? null;
+    $cartSummary = App\Support\Cart::summary();
+    $menu = [
+        ['label' => 'Home', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
+        ['label' => 'Pesanan', 'href' => url('/pesanan'), 'visible' => true],
+    ];
+@endphp
+
+{!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $menu, 'cart' => $cartSummary])->render() !!}
+
+<div class="container-fluid bg-dark hero-header mb-5">
+    <div class="container text-center my-5 pt-5 pb-4">
+        <h1 class="display-3 text-white mb-3 animated slideInDown">Pesanan</h1>
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb justify-content-center text-uppercase">
+                <li class="breadcrumb-item"><a href="{{ url('/') }}">Home</a></li>
+                <li class="breadcrumb-item text-white active" aria-current="page">Pesanan</li>
+            </ol>
+        </nav>
+    </div>
+</div>
+
+<div class="container order-section">
+    @if($feedbackStatus)
+        <div class="feedback-alert {{ $feedbackStatus['type'] ?? 'info' }}">
+            {{ $feedbackStatus['message'] ?? '' }}
+        </div>
+    @endif
+
+    @if($orders->isEmpty())
+        <div class="order-empty">
+            <h3 class="mb-3">Belum ada pesanan</h3>
+            <p class="mb-0">Selesaikan proses checkout untuk melihat riwayat pesanan Anda.</p>
+            <a href="{{ url('/produk') }}">Belanja Sekarang</a>
+        </div>
+    @else
+        @foreach($orders as $order)
+            @php
+                $shippingStatus = optional($order->shipping)->status ?? 'packing';
+                $statusLabel = 'Menunggu Konfirmasi';
+                $statusClass = 'info';
+                if($shippingEnabled) {
+                    $statusLabel = match($shippingStatus) {
+                        'delivered' => 'Tiba di tujuan',
+                        'in_transit' => 'Dalam Pengiriman',
+                        default => 'Sedang Diproses',
+                    };
+                    $statusClass = match($shippingStatus) {
+                        'delivered' => 'success',
+                        'in_transit' => 'warning',
+                        default => 'info',
+                    };
+                } else {
+                    $statusLabel = $order->is_reviewed ? 'Sudah dikonfirmasi admin' : 'Belum dikonfirmasi admin';
+                    $statusClass = $order->is_reviewed ? 'success' : 'warning';
+                }
+                $orderStatus = $order->status === 'paid' ? 'Pembayaran diterima' : ucfirst($order->status);
+            @endphp
+            <div class="order-card">
+                <div class="d-flex justify-content-between flex-wrap mb-4">
+                    <div>
+                        <h2>Pesanan #{{ $order->order_number }}</h2>
+                        <p class="text-muted mb-0">Dibuat pada {{ $order->created_at?->format('d M Y H:i') }}</p>
+                    </div>
+                    <div class="text-end">
+                        <p class="mb-1">Status Pembayaran: {{ $orderStatus }}</p>
+                        <span class="status-pill {{ $statusClass }}">{{ $statusLabel }}</span>
+                    </div>
+                </div>
+
+                <div class="table-responsive">
+                    <table class="table order-table">
+                        <thead>
+                            <tr>
+                                <th>Produk</th>
+                                <th>Harga</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($order->items as $item)
+                                @php
+                                    $product = $item->product;
+                                    $imagePath = optional($product?->images?->first())->path;
+                                    $imageUrl = $imagePath ? asset('storage/' . $imagePath) : 'https://via.placeholder.com/120x120?text=No+Image';
+                                    $productUrl = $product ? route('products.show', $product->id) : '#';
+                                    $subtotal = (int) $item->price * (int) $item->quantity;
+                                @endphp
+                                <tr>
+                                    <td>
+                                        <div class="order-item">
+                                            <img src="{{ $imageUrl }}" alt="{{ $product->name ?? 'Produk' }}">
+                                            <div>
+                                                <a href="{{ $productUrl }}" class="fw-bold text-dark">{{ $product->name ?? 'Produk' }}</a>
+                                                <div class="text-muted small">{{ $item->quantity }} x Rp {{ number_format($item->price ?? 0, 0, ',', '.') }}</div>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td>Rp {{ number_format($subtotal, 0, ',', '.') }}</td>
+                                    <td>
+                                        <span class="status-pill {{ $statusClass }}">{{ $statusLabel }}</span>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="d-flex justify-content-between flex-wrap align-items-center pt-3 mt-3 border-top">
+                    <p class="mb-0 text-muted">Total Produk: {{ $order->items->sum('quantity') }}</p>
+                    <h5 class="mb-0">Total Pembayaran: Rp {{ number_format($order->total_price ?? 0, 0, ',', '.') }}</h5>
+                </div>
+            </div>
+        @endforeach
+    @endif
+</div>
+
+{!! view()->file(base_path('themes/theme-restoran/views/components/footer.blade.php'))->render() !!}
+
+<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/wow/wow.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/easing/easing.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/waypoints/waypoints.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/counterup/counterup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment-timezone.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/tempusdominus-bootstrap-4.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/js/main.js') }}"></script>
+</body>
+</html>

--- a/themes/theme-second/views/order.blade.php
+++ b/themes/theme-second/views/order.blade.php
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pesanan</title>
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/bootstrap.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/font-awesome.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/elegant-icons.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/nice-select.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/jquery-ui.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/owl.carousel.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/slicknav.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/style.css') }}" type="text/css">
+    <style>
+        .breadcrumb__text h1 {
+            font-size: 46px;
+            color: #ffffff;
+            font-weight: 700;
+            text-transform: uppercase;
+            margin-bottom: 10px;
+        }
+        .order-card {
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.08);
+            padding: 2rem;
+            margin-bottom: 2rem;
+        }
+        .order-card__header {
+            display: flex;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+        .order-card__title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            color: #1c1c1c;
+        }
+        .order-card__meta {
+            font-size: 0.95rem;
+            color: #6f6f6f;
+        }
+        .order-table thead {
+            background: #f5f5f5;
+        }
+        .order-table thead th {
+            font-size: 0.9rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            padding: 1rem 1.5rem;
+        }
+        .order-table tbody td {
+            padding: 1.25rem 1.5rem;
+            vertical-align: middle;
+            border-bottom: 1px solid #f2f2f2;
+        }
+        .order-product {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+        .order-product img {
+            width: 72px;
+            height: 72px;
+            object-fit: cover;
+            border-radius: 8px;
+        }
+        .status-badge {
+            display: inline-flex;
+            align-items: center;
+            padding: 0.4rem 0.75rem;
+            border-radius: 999px;
+            font-size: 0.85rem;
+            font-weight: 600;
+        }
+        .status-badge--success {
+            background: rgba(127, 173, 57, 0.15);
+            color: #5c8d1b;
+        }
+        .status-badge--warning {
+            background: rgba(255, 193, 7, 0.15);
+            color: #c28704;
+        }
+        .status-badge--info {
+            background: rgba(52, 152, 219, 0.12);
+            color: #1f6fa8;
+        }
+        .status-badge--danger {
+            background: rgba(220, 53, 69, 0.15);
+            color: #a01e2c;
+        }
+        .order-empty {
+            text-align: center;
+            padding: 3rem 1rem;
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.06);
+        }
+        .alert-feedback {
+            padding: 1rem 1.25rem;
+            border-radius: 12px;
+            margin-bottom: 2rem;
+            font-weight: 600;
+        }
+        .alert-feedback.success { background: rgba(76,175,80,0.12); color: #2e7d32; }
+        .alert-feedback.info { background: rgba(30,136,229,0.12); color: #1e88e5; }
+        .alert-feedback.error { background: rgba(244,67,54,0.12); color: #c62828; }
+    </style>
+</head>
+<body>
+@php
+    $orders = $orders ?? collect();
+    $navLinks = [
+        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
+        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
+        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
+        ['label' => 'Pesanan', 'href' => url('/pesanan'), 'visible' => true],
+    ];
+@endphp
+
+{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => App\Support\Cart::summary()])->render() !!}
+
+<section class="breadcrumb-section set-bg" data-setbg="{{ asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <div class="breadcrumb__text">
+                    <h1>Pesanan</h1>
+                    <div class="breadcrumb__option">
+                        <a href="{{ url('/') }}">Home</a>
+                        <span>Pesanan</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="shoping-cart spad" style="padding-top: 50px;">
+    <div class="container">
+        @if(!empty($feedbackStatus))
+            <div class="alert-feedback {{ $feedbackStatus['type'] ?? 'info' }}">
+                {{ $feedbackStatus['message'] ?? '' }}
+            </div>
+        @endif
+
+        @if($orders->isEmpty())
+            <div class="order-empty">
+                <h4>Belum ada pesanan</h4>
+                <p>Pesanan Anda akan tampil di sini setelah melakukan checkout.</p>
+                <a href="{{ url('/produk') }}" class="primary-btn">Mulai Belanja</a>
+            </div>
+        @else
+            @foreach($orders as $order)
+                @php
+                    $shippingStatus = optional($order->shipping)->status ?? 'packing';
+                    $statusLabel = 'Menunggu Konfirmasi';
+                    $statusClass = 'status-badge--info';
+                    if($shippingEnabled) {
+                        $statusLabel = match($shippingStatus) {
+                            'delivered' => 'Selesai',
+                            'in_transit' => 'Sedang Dikirim',
+                            default => 'Sedang Diproses',
+                        };
+                        $statusClass = match($shippingStatus) {
+                            'delivered' => 'status-badge--success',
+                            'in_transit' => 'status-badge--warning',
+                            default => 'status-badge--info',
+                        };
+                    } else {
+                        $statusLabel = $order->is_reviewed ? 'Sudah dikonfirmasi' : 'Belum dikonfirmasi';
+                        $statusClass = $order->is_reviewed ? 'status-badge--success' : 'status-badge--warning';
+                    }
+                    $orderStatus = $order->status === 'paid' ? 'Pembayaran diterima' : ucfirst($order->status);
+                @endphp
+                <div class="order-card">
+                    <div class="order-card__header">
+                        <div>
+                            <div class="order-card__title">Pesanan #{{ $order->order_number }}</div>
+                            <div class="order-card__meta">Dibuat pada {{ $order->created_at?->format('d M Y H:i') }}</div>
+                        </div>
+                        <div class="text-right">
+                            <div class="order-card__meta">Status Pembayaran: {{ $orderStatus }}</div>
+                            <span class="status-badge {{ $statusClass }}">{{ $statusLabel }}</span>
+                        </div>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table order-table">
+                            <thead>
+                                <tr>
+                                    <th>Produk</th>
+                                    <th class="text-right">Harga</th>
+                                    <th class="text-right">Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($order->items as $item)
+                                    @php
+                                        $product = $item->product;
+                                        $imagePath = optional($product?->images?->first())->path;
+                                        $imageUrl = $imagePath ? asset('storage/' . $imagePath) : 'https://via.placeholder.com/120x120?text=No+Image';
+                                        $productUrl = $product ? route('products.show', $product->id) : '#';
+                                        $subtotal = (int) $item->price * (int) $item->quantity;
+                                    @endphp
+                                    <tr>
+                                        <td>
+                                            <div class="order-product">
+                                                <img src="{{ $imageUrl }}" alt="{{ $product->name ?? 'Produk' }}">
+                                                <div>
+                                                    <a href="{{ $productUrl }}" class="font-weight-bold text-dark">{{ $product->name ?? 'Produk' }}</a>
+                                                    <div class="text-muted small">{{ $item->quantity }} x Rp {{ number_format($item->price ?? 0, 0, ',', '.') }}</div>
+                                                </div>
+                                            </div>
+                                        </td>
+                                        <td class="text-right">Rp {{ number_format($subtotal, 0, ',', '.') }}</td>
+                                        <td class="text-right">
+                                            <span class="status-badge {{ $statusClass }}">{{ $statusLabel }}</span>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="d-flex justify-content-between align-items-center mt-3">
+                        <div class="text-muted">Total Item: {{ $order->items->sum('quantity') }}</div>
+                        <div class="h5 mb-0">Total Pembayaran: Rp {{ number_format($order->total_price ?? 0, 0, ',', '.') }}</div>
+                    </div>
+                </div>
+            @endforeach
+        @endif
+    </div>
+</section>
+
+{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'))->render() !!}
+
+<script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.nice-select.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery-ui.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.slicknav.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/mixitup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/main.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an order controller and front-end route so each theme has a dedicated pesanan page with order status messaging
- persist orders and payments during checkout, update them via gateway callbacks, and store an admin review flag on orders
- add an admin pesanan page that lists payment details, shipping status, and lets admins toggle confirmation when shipping is off

## Testing
- php artisan migrate --force *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- ./vendor/bin/phpunit *(fails: expected HTTP 200, received 500 because the test environment lacks a configured database)*

------
https://chatgpt.com/codex/tasks/task_e_68d32913b1c08329a2d47f1dfc3aeba0