### PR TITLE
Unify theme navigation and footer configuration

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -16,15 +16,6 @@ class PageController extends Controller
         $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
         $settings = PageSetting::where('theme', $theme)->where('page', 'home')->pluck('value', 'key');
         $sections = [
-            'navigation' => [
-                'label' => 'Navigation',
-                'elements' => [
-                    ['type' => 'checkbox', 'label' => 'Homepage link', 'id' => 'navigation.home'],
-                    ['type' => 'checkbox', 'label' => 'Tea Collection link', 'id' => 'navigation.products'],
-                    ['type' => 'checkbox', 'label' => 'News link', 'id' => 'navigation.news'],
-                    ['type' => 'checkbox', 'label' => 'Contact Us link', 'id' => 'navigation.contact'],
-                ],
-            ],
             'hero' => [
                 'label' => 'Hero',
                 'elements' => [
@@ -87,14 +78,6 @@ class PageController extends Controller
                     ['type' => 'textarea', 'label' => 'Map Embed', 'id' => 'contact.map'],
                 ],
             ],
-            'footer' => [
-                'label' => 'Footer',
-                'elements' => [
-                    ['type' => 'checkbox', 'label' => 'Privacy Policy link', 'id' => 'footer.privacy'],
-                    ['type' => 'checkbox', 'label' => 'Terms & Conditions link', 'id' => 'footer.terms'],
-                    ['type' => 'text', 'label' => 'Copyright Text', 'id' => 'footer.copyright'],
-                ],
-            ],
         ];
 
         return view('admin.pages.home', compact('sections', 'settings'));
@@ -134,14 +117,6 @@ class PageController extends Controller
                     ['type' => 'checkbox', 'label' => 'Show Section', 'id' => 'hero.visible'],
                     ['type' => 'image', 'label' => 'Background Image', 'id' => 'hero.image'],
                     ['type' => 'text', 'label' => 'Title', 'id' => 'title'],
-                ],
-            ],
-            'footer' => [
-                'label' => 'Footer',
-                'elements' => [
-                    ['type' => 'checkbox', 'label' => 'Privacy Policy link', 'id' => 'footer.privacy'],
-                    ['type' => 'checkbox', 'label' => 'Terms & Conditions link', 'id' => 'footer.terms'],
-                    ['type' => 'text', 'label' => 'Copyright Text', 'id' => 'footer.copyright'],
                 ],
             ],
         ];
@@ -197,14 +172,6 @@ class PageController extends Controller
                 'elements' => [
                     ['type' => 'checkbox', 'label' => 'Show Section', 'id' => 'recommendations.visible'],
                     ['type' => 'text', 'label' => 'Heading', 'id' => 'recommendations.heading'],
-                ],
-            ],
-            'footer' => [
-                'label' => 'Footer',
-                'elements' => [
-                    ['type' => 'checkbox', 'label' => 'Privacy Policy link', 'id' => 'footer.privacy'],
-                    ['type' => 'checkbox', 'label' => 'Terms & Conditions link', 'id' => 'footer.terms'],
-                    ['type' => 'text', 'label' => 'Copyright Text', 'id' => 'footer.copyright'],
                 ],
             ],
         ];
@@ -265,14 +232,6 @@ class PageController extends Controller
                     ['type' => 'text', 'label' => 'Label Tombol Pembayaran', 'id' => 'button.payment'],
                 ],
             ],
-            'footer' => [
-                'label' => 'Footer',
-                'elements' => [
-                    ['type' => 'checkbox', 'label' => 'Privacy Policy link', 'id' => 'footer.privacy'],
-                    ['type' => 'checkbox', 'label' => 'Terms & Conditions link', 'id' => 'footer.terms'],
-                    ['type' => 'text', 'label' => 'Copyright Text', 'id' => 'footer.copyright'],
-                ],
-            ],
         ];
 
         $previewUrl = route('cart.index');
@@ -296,6 +255,74 @@ class PageController extends Controller
 
         PageSetting::updateOrCreate(
             ['theme' => $theme, 'page' => 'cart', 'key' => $request->input('key')],
+            ['value' => $value]
+        );
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    public function layout()
+    {
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+        $settings = PageSetting::where('theme', $theme)
+            ->where('page', 'layout')
+            ->pluck('value', 'key')
+            ->toArray();
+
+        $sections = [
+            'navigation' => [
+                'label' => 'Navigasi',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Brand', 'id' => 'navigation.brand.visible'],
+                    ['type' => 'text', 'label' => 'Nama Brand', 'id' => 'navigation.brand.text'],
+                    ['type' => 'image', 'label' => 'Logo Brand', 'id' => 'navigation.brand.logo'],
+                    ['type' => 'checkbox', 'label' => 'Tautan Home', 'id' => 'navigation.link.home'],
+                    ['type' => 'checkbox', 'label' => 'Tautan Produk', 'id' => 'navigation.link.products'],
+                    ['type' => 'checkbox', 'label' => 'Tautan Pesanan Saya', 'id' => 'navigation.link.orders'],
+                    ['type' => 'checkbox', 'label' => 'Ikon Keranjang', 'id' => 'navigation.icon.cart'],
+                    ['type' => 'checkbox', 'label' => 'Tombol Login', 'id' => 'navigation.button.login'],
+                ],
+            ],
+            'footer' => [
+                'label' => 'Footer',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Hot Links', 'id' => 'footer.hotlinks.visible'],
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Alamat', 'id' => 'footer.address.visible'],
+                    ['type' => 'textarea', 'label' => 'Alamat', 'id' => 'footer.address.text'],
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Nomor Telepon', 'id' => 'footer.phone.visible'],
+                    ['type' => 'text', 'label' => 'Nomor Telepon', 'id' => 'footer.phone.text'],
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Email', 'id' => 'footer.email.visible'],
+                    ['type' => 'text', 'label' => 'Email', 'id' => 'footer.email.text'],
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Link Media Sosial', 'id' => 'footer.social.visible'],
+                    ['type' => 'text', 'label' => 'Link Media Sosial', 'id' => 'footer.social.text'],
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Jam Operasional', 'id' => 'footer.schedule.visible'],
+                    ['type' => 'text', 'label' => 'Jam Operasional', 'id' => 'footer.schedule.text'],
+                    ['type' => 'text', 'label' => 'Teks Hak Cipta', 'id' => 'footer.copyright'],
+                ],
+            ],
+        ];
+
+        $previewUrl = url('/');
+
+        return view('admin.pages.layout', compact('sections', 'settings', 'previewUrl'));
+    }
+
+    public function updateLayout(Request $request)
+    {
+        $request->validate([
+            'key' => 'required',
+            'value' => 'nullable',
+        ]);
+
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+
+        $value = $request->input('value');
+        if ($request->hasFile('value')) {
+            $value = $request->file('value')->store("pages/{$theme}", 'public');
+        }
+
+        PageSetting::updateOrCreate(
+            ['theme' => $theme, 'page' => 'layout', 'key' => $request->input('key')],
             ['value' => $value]
         );
 

--- a/app/Support/LayoutSettings.php
+++ b/app/Support/LayoutSettings.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\PageSetting;
+
+class LayoutSettings
+{
+    /**
+     * @var array<string, array<string, string|null>>
+     */
+    protected static array $settingsCache = [];
+
+    /**
+     * Get raw layout settings for a theme.
+     */
+    public static function get(string $theme): array
+    {
+        if (! array_key_exists($theme, self::$settingsCache)) {
+            self::$settingsCache[$theme] = PageSetting::where('theme', $theme)
+                ->where('page', 'layout')
+                ->pluck('value', 'key')
+                ->toArray();
+        }
+
+        return self::$settingsCache[$theme];
+    }
+
+    /**
+     * Build navigation configuration from stored settings.
+     */
+    public static function navigation(string $theme): array
+    {
+        $settings = self::get($theme);
+
+        $brandVisible = ($settings['navigation.brand.visible'] ?? '1') === '1';
+        $brandLabel = $settings['navigation.brand.text'] ?? self::defaultBrandLabel($theme);
+        $brandLogo = self::storageAsset($settings['navigation.brand.logo'] ?? null);
+
+        $links = [
+            [
+                'key' => 'home',
+                'label' => 'Home',
+                'href' => url('/'),
+                'visible' => ($settings['navigation.link.home'] ?? '1') === '1',
+            ],
+            [
+                'key' => 'products',
+                'label' => 'Produk',
+                'href' => route('products.index'),
+                'visible' => ($settings['navigation.link.products'] ?? '1') === '1',
+            ],
+            [
+                'key' => 'orders',
+                'label' => 'Pesanan Saya',
+                'href' => route('orders.index'),
+                'visible' => ($settings['navigation.link.orders'] ?? '1') === '1',
+            ],
+        ];
+
+        return [
+            'brand' => [
+                'visible' => $brandVisible,
+                'label' => $brandLabel,
+                'logo' => $brandLogo,
+                'url' => url('/'),
+            ],
+            'links' => $links,
+            'show_cart' => ($settings['navigation.icon.cart'] ?? '1') === '1',
+            'show_login' => ($settings['navigation.button.login'] ?? '1') === '1',
+        ];
+    }
+
+    /**
+     * Build footer configuration from stored settings.
+     */
+    public static function footer(string $theme): array
+    {
+        $settings = self::get($theme);
+        $navigation = self::navigation($theme);
+
+        $links = array_values(array_filter($navigation['links'], function ($link) {
+            return $link['visible'] ?? false;
+        }));
+
+        return [
+            'show_hotlinks' => ($settings['footer.hotlinks.visible'] ?? '1') === '1',
+            'links' => $links,
+            'address' => [
+                'visible' => ($settings['footer.address.visible'] ?? '1') === '1',
+                'text' => $settings['footer.address.text'] ?? 'Jl. Herbal No. 1, Jakarta',
+            ],
+            'phone' => [
+                'visible' => ($settings['footer.phone.visible'] ?? '1') === '1',
+                'text' => $settings['footer.phone.text'] ?? '+62 811-1234-567',
+            ],
+            'email' => [
+                'visible' => ($settings['footer.email.visible'] ?? '1') === '1',
+                'text' => $settings['footer.email.text'] ?? 'hello@example.com',
+            ],
+            'social' => [
+                'visible' => ($settings['footer.social.visible'] ?? '1') === '1',
+                'text' => $settings['footer.social.text'] ?? 'https://instagram.com/yourstore',
+            ],
+            'schedule' => [
+                'visible' => ($settings['footer.schedule.visible'] ?? '1') === '1',
+                'text' => $settings['footer.schedule.text'] ?? 'Senin - Jumat: 09.00 - 18.00',
+            ],
+            'copyright' => $settings['footer.copyright'] ?? ('© ' . date('Y') . ' Herbal Green'),
+        ];
+    }
+
+    protected static function storageAsset(?string $path): ?string
+    {
+        if (! $path) {
+            return null;
+        }
+
+        return asset('storage/' . ltrim($path, '/'));
+    }
+
+    protected static function defaultBrandLabel(string $theme): string
+    {
+        return match ($theme) {
+            'theme-herbalgreen' => 'Herbal Green',
+            'theme-restoran' => 'Restoran',
+            'theme-second' => 'Ogani Store',
+            default => 'Storefront',
+        };
+    }
+}

--- a/resources/views/admin/pages/layout.blade.php
+++ b/resources/views/admin/pages/layout.blade.php
@@ -1,0 +1,105 @@
+@extends('layout.admin')
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="row">
+      <div class="col-md-4" id="elements" style="max-height:100vh; overflow-y:auto;">
+        @foreach ($sections as $key => $section)
+        <div class="card mb-3" data-section="{{ $key }}">
+          <div class="card-header">{{ $section['label'] }}</div>
+          <div class="card-body">
+            @foreach ($section['elements'] as $element)
+              <div class="form-group">
+                @if ($element['type'] === 'checkbox')
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" data-key="{{ $element['id'] }}" {{ ($settings[$element['id']] ?? '1') == '1' ? 'checked' : '' }}>
+                    <label class="form-check-label">{{ $element['label'] }}</label>
+                  </div>
+                @elseif ($element['type'] === 'text')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="text" class="form-control" data-key="{{ $element['id'] }}" value="{{ $settings[$element['id']] ?? '' }}">
+                @elseif ($element['type'] === 'textarea')
+                  <label>{{ $element['label'] }}</label>
+                  <textarea class="form-control" data-key="{{ $element['id'] }}">{{ $settings[$element['id']] ?? '' }}</textarea>
+                @elseif ($element['type'] === 'image')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="file" class="form-control-file" data-key="{{ $element['id'] }}">
+                  @if (!empty($settings[$element['id']]))
+                    <img src="{{ asset('storage/' . $settings[$element['id']]) }}" alt="Preview" class="img-fluid mt-2 rounded" style="max-height:120px; object-fit:contain;">
+                  @endif
+                @endif
+              </div>
+            @endforeach
+          </div>
+        </div>
+        @endforeach
+      </div>
+      <div class="col-md-8 position-sticky" style="top:0;height:100vh">
+        <iframe id="page-preview" src="{{ $previewUrl }}" class="w-100 border h-100"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+const csrf = '{{ csrf_token() }}';
+
+function debounce(fn, delay) {
+  let timer;
+  return function(...args) {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn.apply(this, args), delay);
+  }
+}
+
+const triggerPreviewReload = debounce(function(){
+  const iframe = document.getElementById('page-preview');
+  iframe.contentWindow.location.reload();
+}, 500);
+
+document.querySelectorAll('#elements [data-key]').forEach(function(input){
+  input.addEventListener('change', function(){
+    const key = this.getAttribute('data-key');
+    const formData = new FormData();
+    formData.append('key', key);
+    if(this.type === 'checkbox'){
+      formData.append('value', this.checked ? 1 : 0);
+    }else if(this.type === 'file'){
+      if(this.files[0]){ formData.append('value', this.files[0]); }
+    }else{
+      formData.append('value', this.value);
+    }
+    fetch('{{ route('admin.pages.layout.update') }}', {
+      method: 'POST',
+      headers: {'X-CSRF-TOKEN': csrf},
+      body: formData
+    }).then(() => {
+      triggerPreviewReload();
+    });
+  });
+});
+
+document.querySelectorAll('#elements .card').forEach(function(card){
+  card.addEventListener('mouseenter', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '2px dashed #ff9800';
+      section.scrollIntoView({behavior:'smooth'});
+    }
+  });
+  card.addEventListener('mouseleave', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '';
+    }
+  });
+});
+</script>
+@endsection

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -114,6 +114,7 @@
             </a>
             <div class="collapse" id="pages-menu">
               <ul class="nav flex-column sub-menu">
+                <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/layout')}}">Navigasi & Footer</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/home')}}">Home</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/product')}}">Produk</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/product-detail')}}">Detail Produk</a></li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -145,6 +145,8 @@ Route::prefix('admin')->middleware(['auth'])->group(function () {
         Route::patch('pages/product-detail/comments/{comment}', [PageController::class, 'toggleComment'])->name('admin.pages.product-detail.comments.toggle');
         Route::get('pages/cart', [PageController::class, 'cart'])->name('admin.pages.cart');
         Route::post('pages/cart', [PageController::class, 'updateCart'])->name('admin.pages.cart.update');
+        Route::get('pages/layout', [PageController::class, 'layout'])->name('admin.pages.layout');
+        Route::post('pages/layout', [PageController::class, 'updateLayout'])->name('admin.pages.layout.update');
 
         Route::get('payments', [PaymentController::class, 'index'])->name('admin.payments.index');
         Route::post('payments', [PaymentController::class, 'update'])->name('admin.payments.update');

--- a/themes/theme-herbalgreen/views/cart.blade.php
+++ b/themes/theme-herbalgreen/views/cart.blade.php
@@ -165,18 +165,12 @@
 <body>
 @php
     use App\Support\Cart;
+    use App\Support\LayoutSettings;
 
     $settings = $settings ?? collect();
     $cartSummary = $cartSummary ?? Cart::summary();
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
-    $footerLinks = [
-        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => ($settings['footer.privacy'] ?? '0') == '1'],
-        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => ($settings['footer.terms'] ?? '0') == '1'],
-    ];
+    $navigation = LayoutSettings::navigation($theme);
+    $footerConfig = LayoutSettings::footer($theme);
     $title = $settings['title'] ?? 'Keranjang';
     $subtitle = $settings['subtitle'] ?? 'Periksa kembali item pesanan Anda sebelum melanjutkan.';
     $emptyMessage = $settings['empty.message'] ?? 'Keranjang Anda masih kosong.';
@@ -187,7 +181,13 @@
     $hasItems = !empty($cartSummary['items']);
 @endphp
 
-{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 <section id="cart">
     <h1>{{ $title }}</h1>
@@ -246,8 +246,7 @@
 </section>
 
 {!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
-    'links' => $footerLinks,
-    'copyright' => $settings['footer.copyright'] ?? ('© ' . date('Y') . ' Herbal Green')
+    'footer' => $footerConfig,
 ])->render() !!}
 
 <script>

--- a/themes/theme-herbalgreen/views/components/footer.blade.php
+++ b/themes/theme-herbalgreen/views/components/footer.blade.php
@@ -1,11 +1,85 @@
+@php
+    $footer = $footer ?? [];
+    $links = $footer['links'] ?? [];
+    $showHotlinks = $footer['show_hotlinks'] ?? false;
+    $address = $footer['address'] ?? ['visible' => false, 'text' => ''];
+    $phone = $footer['phone'] ?? ['visible' => false, 'text' => ''];
+    $email = $footer['email'] ?? ['visible' => false, 'text' => ''];
+    $social = $footer['social'] ?? ['visible' => false, 'text' => ''];
+    $schedule = $footer['schedule'] ?? ['visible' => false, 'text' => ''];
+    $copyright = $footer['copyright'] ?? '';
+@endphp
 <footer id="footer">
-    <ul class="footer-links">
-        @foreach ($links as $link)
-            @if ($link['visible'])
+    @if ($showHotlinks && count($links))
+        <ul class="footer-links">
+            @foreach ($links as $link)
                 <li><a href="{{ $link['href'] }}">{{ $link['label'] }}</a></li>
-            @endif
-        @endforeach
-    </ul>
-    <p>{{ $copyright }}</p>
+            @endforeach
+        </ul>
+    @endif
+    <div class="footer-info">
+        @if ($address['visible'] ?? false)
+            <p class="footer-info__item">📍 {{ $address['text'] }}</p>
+        @endif
+        @if ($phone['visible'] ?? false)
+            <p class="footer-info__item">📞 <a href="tel:{{ preg_replace('/[^0-9+]/', '', $phone['text']) }}">{{ $phone['text'] }}</a></p>
+        @endif
+        @if ($email['visible'] ?? false)
+            <p class="footer-info__item">✉️ <a href="mailto:{{ $email['text'] }}">{{ $email['text'] }}</a></p>
+        @endif
+        @if ($social['visible'] ?? false)
+            <p class="footer-info__item">🔗 <a href="{{ $social['text'] }}" target="_blank" rel="noopener">{{ $social['text'] }}</a></p>
+        @endif
+        @if ($schedule['visible'] ?? false)
+            <p class="footer-info__item">🕒 {{ $schedule['text'] }}</p>
+        @endif
+    </div>
+    @if (!empty($copyright))
+        <p class="footer-copy">{{ $copyright }}</p>
+    @endif
 </footer>
 
+@once
+    <style>
+        #footer {
+            margin-top: 4rem;
+            padding: 2.5rem 2rem;
+            background: var(--color-dark, #1b1b1b);
+            color: #fff;
+            text-align: center;
+        }
+
+        #footer .footer-links {
+            list-style: none;
+            padding: 0;
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 1.25rem;
+            margin-bottom: 1.75rem;
+        }
+
+        #footer .footer-links a,
+        #footer .footer-info a {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        #footer .footer-info {
+            display: grid;
+            gap: 0.35rem;
+            margin-bottom: 1.5rem;
+        }
+
+        #footer .footer-info__item {
+            margin: 0;
+            font-size: 0.95rem;
+        }
+
+        #footer .footer-copy {
+            margin: 0;
+            font-size: 0.85rem;
+            opacity: 0.75;
+        }
+    </style>
+@endonce

--- a/themes/theme-herbalgreen/views/components/nav-menu.blade.php
+++ b/themes/theme-herbalgreen/views/components/nav-menu.blade.php
@@ -1,8 +1,21 @@
 @php
     $cartSummary = $cart ?? ['total_quantity' => 0, 'total_price_formatted' => '0'];
+    $brand = $brand ?? ['visible' => true, 'label' => 'TEA', 'logo' => null, 'url' => url('/')];
+    $links = $links ?? [];
+    $showCart = $showCart ?? true;
+    $showLogin = $showLogin ?? false;
+    $showIcons = $showCart || $showLogin;
 @endphp
 <header id="navigation" class="site-header">
-    <div class="logo">TEA</div>
+    @if ($brand['visible'])
+        <a href="{{ $brand['url'] ?? url('/') }}" class="logo">
+            @if (!empty($brand['logo']))
+                <img src="{{ $brand['logo'] }}" alt="{{ $brand['label'] }}" />
+            @else
+                <span>{{ $brand['label'] }}</span>
+            @endif
+        </a>
+    @endif
     <nav class="main-nav">
         <ul>
             @foreach ($links as $link)
@@ -12,18 +25,55 @@
             @endforeach
         </ul>
     </nav>
-    <div class="header-icons">
-        <span>🔍</span>
-        <span>👤</span>
-        <a href="{{ route('cart.index') }}" class="cart-indicator" data-cart-link>
-            <span class="icon">🛒</span>
-            <span class="cart-count" data-cart-count data-count="{{ $cartSummary['total_quantity'] ?? 0 }}">{{ $cartSummary['total_quantity'] ?? 0 }}</span>
-        </a>
-    </div>
+    @if ($showIcons)
+        <div class="header-icons">
+            @if ($showLogin)
+                @auth
+                    <a href="{{ route('orders.index') }}" class="login-link">Akun Saya</a>
+                @else
+                    <a href="{{ route('login') }}" class="login-link">Login</a>
+                @endauth
+            @endif
+            @if ($showCart)
+                <a href="{{ route('cart.index') }}" class="cart-indicator" data-cart-link>
+                    <span class="icon">🛒</span>
+                    <span class="cart-count" data-cart-count data-count="{{ $cartSummary['total_quantity'] ?? 0 }}">{{ $cartSummary['total_quantity'] ?? 0 }}</span>
+                </a>
+            @endif
+        </div>
+    @endif
 </header>
 
 @once
     <style>
+        .header-icons {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .logo {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-weight: 700;
+            font-size: 1.15rem;
+            text-decoration: none;
+            color: inherit;
+        }
+
+        .logo img {
+            height: 40px;
+            width: auto;
+            object-fit: contain;
+        }
+
+        .login-link {
+            text-decoration: none;
+            font-weight: 600;
+            color: inherit;
+        }
+
         .cart-indicator {
             display: inline-flex;
             align-items: center;

--- a/themes/theme-herbalgreen/views/home.blade.php
+++ b/themes/theme-herbalgreen/views/home.blade.php
@@ -12,25 +12,23 @@
     use App\Models\PageSetting;
     use App\Models\Product;
     use App\Support\Cart;
+    use App\Support\LayoutSettings;
     $settings = PageSetting::where('theme', $theme)->where('page', 'home')->pluck('value', 'key')->toArray();
     $products = Product::where('is_featured', true)->latest()->take(5)->get();
     $testimonials = json_decode($settings['testimonials.items'] ?? '[]', true);
     $services = json_decode($settings['services.items'] ?? '[]', true);
 
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => '#hero', 'visible' => ($settings['navigation.home'] ?? '1') == '1'],
-        ['label' => 'Tea Collection', 'href' => '#products', 'visible' => ($settings['navigation.products'] ?? '1') == '1'],
-        ['label' => 'News', 'href' => '#testimonials', 'visible' => ($settings['navigation.news'] ?? '1') == '1'],
-        ['label' => 'Contact Us', 'href' => '#contact', 'visible' => ($settings['navigation.contact'] ?? '1') == '1'],
-    ];
-
-    $footerLinks = [
-        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => ($settings['footer.privacy'] ?? '1') == '1'],
-        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => ($settings['footer.terms'] ?? '1') == '1'],
-    ];
+    $navigation = LayoutSettings::navigation($theme);
+    $footerConfig = LayoutSettings::footer($theme);
     $cartSummary = Cart::summary();
 @endphp
-{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 @if(($settings['hero.visible'] ?? '1') == '1')
 <section id="hero" class="hero" @if(!empty($settings['hero.image'])) style="background-image:url('{{ asset('storage/'.$settings['hero.image']) }}')" @endif>
@@ -106,6 +104,8 @@
 </section>
 @endif
 
-{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), ['links' => $footerLinks, 'copyright' => $settings['footer.copyright'] ?? ('© ' . date('Y') . ' Herbal Green')])->render() !!}
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 </body>
 </html>

--- a/themes/theme-herbalgreen/views/order.blade.php
+++ b/themes/theme-herbalgreen/views/order.blade.php
@@ -123,18 +123,23 @@
 </head>
 <body>
 @php
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+
     $orders = $orders ?? collect();
     $feedbackStatus = $feedbackStatus ?? null;
-    $cartSummary = App\Support\Cart::summary();
-    $links = [
-        ['label' => 'Home', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-        ['label' => 'Pesanan', 'href' => url('/pesanan'), 'visible' => true],
-    ];
+    $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($theme);
+    $footerConfig = LayoutSettings::footer($theme);
 @endphp
 
-{!! view()->file(base_path('themes/theme-herbalgreen/views/components/nav-menu.blade.php'), ['links' => $links, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/theme-herbalgreen/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 <section id="orders">
     <h1>Pesanan</h1>
@@ -232,6 +237,8 @@
     @endif
 </section>
 
-{!! view()->file(base_path('themes/theme-herbalgreen/views/components/footer.blade.php'))->render() !!}
+{!! view()->file(base_path('themes/theme-herbalgreen/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 </body>
 </html>

--- a/themes/theme-herbalgreen/views/payment.blade.php
+++ b/themes/theme-herbalgreen/views/payment.blade.php
@@ -159,15 +159,10 @@
 </head>
 <body>
 @php
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
-    $footerLinks = [
-        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => true],
-        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => true],
-    ];
+    use App\Support\LayoutSettings;
+
+    $navigation = LayoutSettings::navigation($theme);
+    $footerConfig = LayoutSettings::footer($theme);
     $summaryItems = $cartSummary['items'] ?? [];
     $instructions = $checkoutData['instructions'] ?? [];
     $subtitle = $checkoutData['subtitle'] ?? 'Selesaikan pembayaran Anda dengan aman.';
@@ -177,7 +172,13 @@
     $feedbackType = $feedbackStatus['type'] ?? null;
 @endphp
 
-{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 <section id="payment">
     <div class="payment-header">
@@ -247,8 +248,7 @@
 </section>
 
 {!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
-    'links' => $footerLinks,
-    'copyright' => '© ' . date('Y') . ' Herbal Green'
+    'footer' => $footerConfig,
 ])->render() !!}
 
 <script>

--- a/themes/theme-herbalgreen/views/product-detail.blade.php
+++ b/themes/theme-herbalgreen/views/product-detail.blade.php
@@ -33,20 +33,13 @@
     use App\Models\PageSetting;
     use App\Models\Product;
     use App\Support\Cart;
+    use App\Support\LayoutSettings;
 
     $settings = PageSetting::where('theme', $theme)->where('page', 'product-detail')->pluck('value', 'key')->toArray();
 
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
+    $navigation = LayoutSettings::navigation($theme);
+    $footerConfig = LayoutSettings::footer($theme);
     $cartSummary = Cart::summary();
-
-    $footerLinks = [
-        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => ($settings['footer.privacy'] ?? '0') == '1'],
-        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => ($settings['footer.terms'] ?? '0') == '1'],
-    ];
 
     $images = $product->images ?? collect();
     $primaryImage = optional($images->first())->path;
@@ -72,7 +65,13 @@
         $recommendations = $recommendations->concat($fallback);
     }
 @endphp
-{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 @if(($settings['hero.visible'] ?? '1') == '1')
 <section id="hero" class="hero" @if(!empty($settings['hero.image'])) style="background-image:url('{{ asset('storage/'.$settings['hero.image']) }}')" @endif>
@@ -149,8 +148,7 @@
 @endif
 
 {!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
-    'links' => $footerLinks,
-    'copyright' => $settings['footer.copyright'] ?? ('© '.date('Y') . ' Herbal Green')
+    'footer' => $footerConfig,
 ])->render() !!}
 
 <script>

--- a/themes/theme-herbalgreen/views/product.blade.php
+++ b/themes/theme-herbalgreen/views/product.blade.php
@@ -13,6 +13,7 @@
     use App\Models\Product;
     use App\Models\Category;
     use App\Support\Cart;
+    use App\Support\LayoutSettings;
     $settings = PageSetting::where('theme', $theme)->where('page', 'product')->pluck('value', 'key')->toArray();
     $query = Product::query();
     if($s = request('search')){ $query->where('name', 'like', "%$s%"); }
@@ -24,14 +25,17 @@
     }
     $products = $query->paginate(15)->withQueryString();
     $categories = Category::all();
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
+    $navigation = LayoutSettings::navigation($theme);
+    $footerConfig = LayoutSettings::footer($theme);
     $cartSummary = Cart::summary();
 @endphp
-{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 @if(($settings['hero.visible'] ?? '1') == '1')
 <section id="hero" class="hero" @if(!empty($settings['hero.image'])) style="background-image:url('{{ asset('storage/'.$settings['hero.image']) }}')" @endif>
     <div class="hero-content">
@@ -73,6 +77,8 @@
         {{ $products->links() }}
     </div>
 </section>
-{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), ['links' => [], 'copyright' => $settings['footer.copyright'] ?? ('© '.date('Y'))])->render() !!}
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 </body>
 </html>

--- a/themes/theme-restoran/views/cart.blade.php
+++ b/themes/theme-restoran/views/cart.blade.php
@@ -105,14 +105,13 @@
 <body>
 @php
     use App\Support\Cart;
+    use App\Support\LayoutSettings;
 
+    $themeName = $theme ?? 'theme-restoran';
     $settings = $settings ?? collect();
     $cartSummary = $cartSummary ?? Cart::summary();
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
     $title = $settings['title'] ?? 'Keranjang';
     $subtitle = $settings['subtitle'] ?? 'Nikmati kemudahan berbelanja dengan memeriksa pesanan Anda di sini.';
     $emptyMessage = $settings['empty.message'] ?? 'Keranjang masih kosong, mulai belanja sekarang!';
@@ -124,7 +123,13 @@
 @endphp
 
 <div class="container-xxl position-relative p-0">
-    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+    {!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+        'brand' => $navigation['brand'],
+        'links' => $navigation['links'],
+        'showCart' => $navigation['show_cart'],
+        'showLogin' => $navigation['show_login'],
+        'cart' => $cartSummary,
+    ])->render() !!}
     <div class="container-xxl py-5 bg-dark hero-header mb-5">
         <div class="container text-center my-5 pt-5 pb-4">
             <h1 class="display-3 text-white mb-3">{{ $title }}</h1>
@@ -193,7 +198,9 @@
     </div>
 </div>
 
-{!! view()->file(base_path('themes/theme-restoran/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 
 <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/themes/theme-restoran/views/components/footer.blade.php
+++ b/themes/theme-restoran/views/components/footer.blade.php
@@ -1,60 +1,59 @@
-<div class="container-fluid bg-dark text-light footer pt-5 mt-5 wow fadeIn" data-wow-delay="0.1s">
+@php
+    $footer = $footer ?? [];
+    $links = $footer['links'] ?? [];
+    $showHotlinks = $footer['show_hotlinks'] ?? false;
+    $address = $footer['address'] ?? ['visible' => false, 'text' => ''];
+    $phone = $footer['phone'] ?? ['visible' => false, 'text' => ''];
+    $email = $footer['email'] ?? ['visible' => false, 'text' => ''];
+    $social = $footer['social'] ?? ['visible' => false, 'text' => ''];
+    $schedule = $footer['schedule'] ?? ['visible' => false, 'text' => ''];
+    $copyright = $footer['copyright'] ?? '';
+@endphp
+<div id="footer" class="container-fluid bg-dark text-light footer pt-5 mt-5">
     <div class="container py-5">
         <div class="row g-5">
-            <div class="col-lg-3 col-md-6">
-                <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Company</h4>
-                <a class="btn btn-link" href="#">About Us</a>
-                <a class="btn btn-link" href="#">Contact Us</a>
-                <a class="btn btn-link" href="#">Reservation</a>
-                <a class="btn btn-link" href="#">Privacy Policy</a>
-                <a class="btn btn-link" href="#">Terms & Condition</a>
-            </div>
-            <div class="col-lg-3 col-md-6">
-                <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Contact</h4>
-                <p class="mb-2"><i class="fa fa-map-marker-alt me-3"></i>123 Street, New York, USA</p>
-                <p class="mb-2"><i class="fa fa-phone-alt me-3"></i>+012 345 67890</p>
-                <p class="mb-2"><i class="fa fa-envelope me-3"></i>info@example.com</p>
-                <div class="d-flex pt-2">
-                    <a class="btn btn-outline-light btn-social" href="#"><i class="fab fa-twitter"></i></a>
-                    <a class="btn btn-outline-light btn-social" href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a class="btn btn-outline-light btn-social" href="#"><i class="fab fa-youtube"></i></a>
-                    <a class="btn btn-outline-light btn-social" href="#"><i class="fab fa-linkedin-in"></i></a>
+            @if ($showHotlinks && count($links))
+                <div class="col-lg-3 col-md-6">
+                    <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Hot Links</h4>
+                    @foreach ($links as $link)
+                        <a class="btn btn-link" href="{{ $link['href'] }}">{{ $link['label'] }}</a>
+                    @endforeach
                 </div>
-            </div>
-            <div class="col-lg-3 col-md-6">
-                <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Opening</h4>
-                <h5 class="text-light fw-normal">Monday - Saturday</h5>
-                <p>09AM - 09PM</p>
-                <h5 class="text-light fw-normal">Sunday</h5>
-                <p>10AM - 08PM</p>
-            </div>
-            <div class="col-lg-3 col-md-6">
-                <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Newsletter</h4>
-                <p>Dolor amet sit justo amet elitr clita ipsum elitr est.</p>
-                <div class="position-relative mx-auto" style="max-width: 400px;">
-                    <input class="form-control border-primary w-100 py-3 ps-4 pe-5" type="text" placeholder="Your email">
-                    <button type="button" class="btn btn-primary py-2 position-absolute top-0 end-0 mt-2 me-2">SignUp</button>
+            @endif
+            @if (($address['visible'] ?? false) || ($phone['visible'] ?? false) || ($email['visible'] ?? false) || ($social['visible'] ?? false))
+                <div class="col-lg-4 col-md-6">
+                    <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Contact</h4>
+                    @if ($address['visible'] ?? false)
+                        <p class="mb-2"><i class="fa fa-map-marker-alt me-3"></i>{{ $address['text'] }}</p>
+                    @endif
+                    @if ($phone['visible'] ?? false)
+                        <p class="mb-2"><i class="fa fa-phone-alt me-3"></i><a href="tel:{{ preg_replace('/[^0-9+]/', '', $phone['text']) }}" class="text-light text-decoration-none">{{ $phone['text'] }}</a></p>
+                    @endif
+                    @if ($email['visible'] ?? false)
+                        <p class="mb-2"><i class="fa fa-envelope me-3"></i><a href="mailto:{{ $email['text'] }}" class="text-light text-decoration-none">{{ $email['text'] }}</a></p>
+                    @endif
+                    @if ($social['visible'] ?? false)
+                        <div class="d-flex pt-2">
+                            <a class="btn btn-outline-light btn-social" href="{{ $social['text'] }}" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+                        </div>
+                    @endif
                 </div>
-            </div>
+            @endif
+            @if ($schedule['visible'] ?? false)
+                <div class="col-lg-3 col-md-6">
+                    <h4 class="section-title ff-secondary text-start text-primary fw-normal mb-4">Opening</h4>
+                    <p class="mb-2">{{ $schedule['text'] }}</p>
+                </div>
+            @endif
         </div>
     </div>
     <div class="container">
         <div class="copyright">
             <div class="row">
-                <div class="col-md-6 text-center text-md-start mb-3 mb-md-0">
-                    {{ $settings['footer.copyright'] ?? '© ' . date('Y') . ' Restoran' }}
-                    @if(($settings['footer.privacy'] ?? '0') == '1') | <a class="border-bottom" href="#">Privacy Policy</a>@endif
-                    @if(($settings['footer.terms'] ?? '0') == '1') | <a class="border-bottom" href="#">Terms & Conditions</a>@endif
-                    <br>Designed By <a class="border-bottom" href="https://htmlcodex.com">HTML Codex</a><br>
-                    Distributed By <a class="border-bottom" href="https://themewagon.com" target="_blank">ThemeWagon</a>
-                </div>
-                <div class="col-md-6 text-center text-md-end">
-                    <div class="footer-menu">
-                        <a href="#">Home</a>
-                        <a href="#">Cookies</a>
-                        <a href="#">Help</a>
-                        <a href="#">FQAs</a>
-                    </div>
+                <div class="col-12 text-center">
+                    @if (!empty($copyright))
+                        <span>{{ $copyright }}</span>
+                    @endif
                 </div>
             </div>
         </div>

--- a/themes/theme-restoran/views/components/nav-menu.blade.php
+++ b/themes/theme-restoran/views/components/nav-menu.blade.php
@@ -1,10 +1,24 @@
 @php
     $cartSummary = $cart ?? ['total_quantity' => 0, 'total_price_formatted' => '0'];
+    $brand = $brand ?? ['visible' => true, 'label' => 'Restoran', 'logo' => null, 'url' => url('/')];
+    $links = $links ?? [];
+    $showCart = $showCart ?? true;
+    $showLogin = $showLogin ?? false;
+    $showIcons = $showCart || $showLogin;
 @endphp
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark px-4 px-lg-5 py-3 py-lg-0">
-    <a href="{{ url('/') }}" class="navbar-brand p-0">
-        <h1 class="text-primary m-0"><i class="fa fa-utensils me-3"></i>Restoran</h1>
-    </a>
+<nav id="navigation" class="navbar navbar-expand-lg navbar-dark bg-dark px-4 px-lg-5 py-3 py-lg-0">
+    @if ($brand['visible'])
+        <a href="{{ $brand['url'] ?? url('/') }}" class="navbar-brand p-0 d-flex align-items-center gap-2">
+            <span class="text-primary d-inline-flex align-items-center justify-content-center" style="font-size: 1.5rem;">
+                <i class="fa fa-utensils"></i>
+            </span>
+            @if (!empty($brand['logo']))
+                <img src="{{ $brand['logo'] }}" alt="{{ $brand['label'] }}" class="img-fluid" style="max-height: 46px; width: auto;">
+            @else
+                <span class="text-primary fw-bold fs-3 mb-0">{{ $brand['label'] }}</span>
+            @endif
+        </a>
+    @endif
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse">
         <span class="fa fa-bars"></span>
     </button>
@@ -16,13 +30,23 @@
                 @endif
             @endforeach
         </div>
-        <div class="d-flex align-items-center gap-2">
-            <a href="{{ route('cart.index') }}" class="btn btn-outline-light cart-indicator position-relative">
-                <i class="bi bi-cart"></i>
-                <span class="badge bg-primary rounded-pill cart-count" data-cart-count data-count="{{ $cartSummary['total_quantity'] ?? 0 }}">{{ $cartSummary['total_quantity'] ?? 0 }}</span>
-            </a>
-            <a href="#" class="btn btn-primary py-2 px-4">Book A Table</a>
-        </div>
+        @if ($showIcons)
+            <div class="d-flex align-items-center gap-2">
+                @if ($showLogin)
+                    @auth
+                        <a href="{{ route('orders.index') }}" class="btn btn-outline-light">Akun Saya</a>
+                    @else
+                        <a href="{{ route('login') }}" class="btn btn-primary">Login</a>
+                    @endauth
+                @endif
+                @if ($showCart)
+                    <a href="{{ route('cart.index') }}" class="btn btn-outline-light cart-indicator position-relative">
+                        <i class="bi bi-cart"></i>
+                        <span class="badge bg-primary rounded-pill cart-count" data-cart-count data-count="{{ $cartSummary['total_quantity'] ?? 0 }}">{{ $cartSummary['total_quantity'] ?? 0 }}</span>
+                    </a>
+                @endif
+            </div>
+        @endif
     </div>
 </nav>
 

--- a/themes/theme-restoran/views/home.blade.php
+++ b/themes/theme-restoran/views/home.blade.php
@@ -31,21 +31,25 @@
     use App\Models\PageSetting;
     use App\Models\Product;
     use App\Support\Cart;
-    $settings = PageSetting::where('theme', 'theme-restoran')->where('page', 'home')->pluck('value', 'key')->toArray();
+    use App\Support\LayoutSettings;
+    $themeName = $theme ?? 'theme-restoran';
+    $settings = PageSetting::where('theme', $themeName)->where('page', 'home')->pluck('value', 'key')->toArray();
     $products = Product::where('is_featured', true)->latest()->take(5)->get();
     $testimonials = json_decode($settings['testimonials.items'] ?? '[]', true);
     $services = json_decode($settings['services.items'] ?? '[]', true);
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => '#hero', 'visible' => ($settings['navigation.home'] ?? '1') == '1'],
-        ['label' => 'Menu', 'href' => '#products', 'visible' => ($settings['navigation.products'] ?? '1') == '1'],
-        ['label' => 'Testimonials', 'href' => '#testimonials', 'visible' => ($settings['navigation.news'] ?? '1') == '1'],
-        ['label' => 'Contact', 'href' => '#contact', 'visible' => ($settings['navigation.contact'] ?? '1') == '1'],
-    ];
     $aboutImage = $settings['about.image'] ?? null;
     $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
 @endphp
 <div class="container-xxl position-relative p-0">
-    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+    {!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+        'brand' => $navigation['brand'],
+        'links' => $navigation['links'],
+        'showCart' => $navigation['show_cart'],
+        'showLogin' => $navigation['show_login'],
+        'cart' => $cartSummary,
+    ])->render() !!}
     @if(($settings['hero.visible'] ?? '1') == '1')
     <div id="hero" class="container-xxl py-5 bg-dark hero-header mb-5">
         <div class="container my-5 py-5">
@@ -214,7 +218,9 @@
     </div>
 </div>
 @endif
-{!! view()->file(base_path('themes/theme-restoran/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 <a href="#" class="btn btn-lg btn-primary btn-lg-square back-to-top"><i class="bi bi-arrow-up"></i></a>
 <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/themes/theme-restoran/views/order.blade.php
+++ b/themes/theme-restoran/views/order.blade.php
@@ -98,18 +98,24 @@
 </head>
 <body>
 @php
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+
+    $themeName = $theme ?? 'theme-restoran';
     $orders = $orders ?? collect();
     $feedbackStatus = $feedbackStatus ?? null;
-    $cartSummary = App\Support\Cart::summary();
-    $menu = [
-        ['label' => 'Home', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-        ['label' => 'Pesanan', 'href' => url('/pesanan'), 'visible' => true],
-    ];
+    $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
 @endphp
 
-{!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $menu, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 <div class="container-fluid bg-dark hero-header mb-5">
     <div class="container text-center my-5 pt-5 pb-4">
@@ -218,7 +224,9 @@
     @endif
 </div>
 
-{!! view()->file(base_path('themes/theme-restoran/views/components/footer.blade.php'))->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 
 <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/themes/theme-restoran/views/payment.blade.php
+++ b/themes/theme-restoran/views/payment.blade.php
@@ -48,15 +48,11 @@
 </head>
 <body>
 @php
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Menu', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
-    $footerLinks = [
-        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => true],
-        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => true],
-    ];
+    use App\Support\LayoutSettings;
+
+    $themeName = $theme ?? 'theme-restoran';
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
     $items = $cartSummary['items'] ?? [];
     $instructions = $checkoutData['instructions'] ?? [];
     $publicConfig = $checkoutData['publicConfig'] ?? [];
@@ -65,7 +61,13 @@
     $feedbackType = $feedbackStatus['type'] ?? null;
 @endphp
 
-{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 <div class="container-xxl py-5">
     <div class="container">
@@ -151,7 +153,9 @@
     </div>
 </div>
 
-{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), ['links' => $footerLinks])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 
 <script src="{{ asset('storage/themes/theme-restoran/js/bootstrap.bundle.min.js') }}"></script>
 <script>

--- a/themes/theme-restoran/views/product-detail.blade.php
+++ b/themes/theme-restoran/views/product-detail.blade.php
@@ -33,14 +33,13 @@
     use App\Models\PageSetting;
     use App\Models\Product;
     use App\Support\Cart;
+    use App\Support\LayoutSettings;
 
-    $settings = PageSetting::where('theme', 'theme-restoran')->where('page', 'product-detail')->pluck('value','key')->toArray();
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
+    $themeName = $theme ?? 'theme-restoran';
+    $settings = PageSetting::where('theme', $themeName)->where('page', 'product-detail')->pluck('value','key')->toArray();
     $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
 
     $images = $product->images ?? collect();
     $imageSources = $images->pluck('path')->filter()->map(fn($path) => asset('storage/'.$path))->values();
@@ -65,7 +64,13 @@
     }
 @endphp
 <div class="container-xxl position-relative p-0">
-    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+    {!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+        'brand' => $navigation['brand'],
+        'links' => $navigation['links'],
+        'showCart' => $navigation['show_cart'],
+        'showLogin' => $navigation['show_login'],
+        'cart' => $cartSummary,
+    ])->render() !!}
     @if(($settings['hero.visible'] ?? '1') == '1')
     <div class="container-xxl py-5 bg-dark hero-header mb-5" @if(!empty($settings['hero.image'])) style="background-image:url('{{ asset('storage/'.$settings['hero.image']) }}'); background-size:cover; background-position:center;" @endif>
         <div class="container text-center my-5 pt-5 pb-4">
@@ -169,7 +174,9 @@
 </div>
 @endif
 
-{!! view()->file(base_path('themes/theme-restoran/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 
 <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/themes/theme-restoran/views/product.blade.php
+++ b/themes/theme-restoran/views/product.blade.php
@@ -22,7 +22,9 @@
     use App\Models\Product;
     use App\Models\Category;
     use App\Support\Cart;
-    $settings = PageSetting::where('theme', 'theme-restoran')->where('page', 'product')->pluck('value','key')->toArray();
+    use App\Support\LayoutSettings;
+    $themeName = $theme ?? 'theme-restoran';
+    $settings = PageSetting::where('theme', $themeName)->where('page', 'product')->pluck('value','key')->toArray();
     $query = Product::query();
     if($s = request('search')){ $query->where('name','like',"%$s%"); }
     if($cat = request('category')){ $query->whereHas('categories', fn($q)=>$q->where('slug',$cat)); }
@@ -33,15 +35,18 @@
     }
     $products = $query->paginate(15)->withQueryString();
     $categories = Category::all();
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
     $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
 @endphp
 <div class="container-xxl position-relative p-0">
-    {!! view()->file(base_path('themes/theme-restoran/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+    {!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+        'brand' => $navigation['brand'],
+        'links' => $navigation['links'],
+        'showCart' => $navigation['show_cart'],
+        'showLogin' => $navigation['show_login'],
+        'cart' => $cartSummary,
+    ])->render() !!}
     <div class="container-xxl py-5 bg-dark hero-header mb-5">
         <div class="container text-center my-5 pt-5 pb-4">
             <h1 class="display-3 text-white mb-3">{{ $settings['title'] ?? 'Produk Kami' }}</h1>
@@ -101,7 +106,9 @@
         {{ $products->links() }}
     </div>
 </div>
-{!! view()->file(base_path('themes/theme-restoran/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{{ asset('storage/themes/theme-restoran/lib/wow/wow.min.js') }}"></script>

--- a/themes/theme-second/views/cart.blade.php
+++ b/themes/theme-second/views/cart.blade.php
@@ -123,14 +123,13 @@
 <body>
 @php
     use App\Support\Cart;
+    use App\Support\LayoutSettings;
 
+    $themeName = $theme ?? 'theme-second';
     $settings = $settings ?? collect();
     $cartSummary = $cartSummary ?? Cart::summary();
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
     $title = $settings['title'] ?? 'Keranjang';
     $subtitle = $settings['subtitle'] ?? 'Periksa kembali daftar belanja Anda.';
     $emptyMessage = $settings['empty.message'] ?? 'Keranjang Anda masih kosong.';
@@ -141,7 +140,13 @@
     $hasItems = !empty($cartSummary['items']);
 @endphp
 
-{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 <section class="breadcrumb-section set-bg" data-setbg="{{ asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
     <div class="container">
@@ -226,7 +231,9 @@
     </div>
 </section>
 
-{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 
 <script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
 <script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>

--- a/themes/theme-second/views/components/footer.blade.php
+++ b/themes/theme-second/views/components/footer.blade.php
@@ -1,61 +1,69 @@
-<footer class="footer spad">
+@php
+    $footer = $footer ?? [];
+    $links = $footer['links'] ?? [];
+    $showHotlinks = $footer['show_hotlinks'] ?? false;
+    $address = $footer['address'] ?? ['visible' => false, 'text' => ''];
+    $phone = $footer['phone'] ?? ['visible' => false, 'text' => ''];
+    $email = $footer['email'] ?? ['visible' => false, 'text' => ''];
+    $social = $footer['social'] ?? ['visible' => false, 'text' => ''];
+    $schedule = $footer['schedule'] ?? ['visible' => false, 'text' => ''];
+    $copyright = $footer['copyright'] ?? '';
+@endphp
+<footer id="footer" class="footer spad">
     <div class="container">
         <div class="row">
-            <div class="col-lg-3 col-md-6 col-sm-6">
-                <div class="footer__about">
-                    <div class="footer__about__logo">
-                        <a href="{{ url('/') }}"><img src="{{ asset('storage/themes/theme-second/img/logo.png') }}" alt=""></a>
-                    </div>
-                    <ul>
-                        <li>Address: 60-49 Road 11378 New York</li>
-                        <li>Phone: +65 11.188.888</li>
-                        <li>Email: hello@colorlib.com</li>
-                    </ul>
-                </div>
-            </div>
-            <div class="col-lg-4 col-md-6 col-sm-6 offset-lg-1">
-                <div class="footer__widget">
-                    <h6>Useful Links</h6>
-                    <ul>
-                        <li><a href="#">About Us</a></li>
-                        <li><a href="#">About Our Shop</a></li>
-                        <li><a href="#">Secure Shopping</a></li>
-                        <li><a href="#">Delivery infomation</a></li>
-                        <li><a href="#">Privacy Policy</a></li>
-                        <li><a href="#">Our Sitemap</a></li>
-                    </ul>
-                    <ul>
-                        <li><a href="#">Who We Are</a></li>
-                        <li><a href="#">Our Services</a></li>
-                        <li><a href="#">Projects</a></li>
-                        <li><a href="#">Contact</a></li>
-                        <li><a href="#">Innovation</a></li>
-                        <li><a href="#">Testimonials</a></li>
-                    </ul>
-                </div>
-            </div>
-            <div class="col-lg-4 col-md-12">
-                <div class="footer__widget">
-                    <h6>Join Our Newsletter Now</h6>
-                    <p>Get E-mail updates about our latest shop and special offers.</p>
-                    <form action="#">
-                        <input type="text" placeholder="Enter your mail">
-                        <button type="submit" class="site-btn">Subscribe</button>
-                    </form>
-                    <div class="footer__widget__social">
-                        <a href="#"><i class="fa fa-facebook"></i></a>
-                        <a href="#"><i class="fa fa-instagram"></i></a>
-                        <a href="#"><i class="fa fa-twitter"></i></a>
-                        <a href="#"><i class="fa fa-pinterest"></i></a>
+            @if (($address['visible'] ?? false) || ($phone['visible'] ?? false) || ($email['visible'] ?? false))
+                <div class="col-lg-4 col-md-6 col-sm-6">
+                    <div class="footer__about">
+                        <h6 class="text-uppercase mb-3">Hubungi Kami</h6>
+                        <ul>
+                            @if ($address['visible'] ?? false)
+                                <li>Alamat: {{ $address['text'] }}</li>
+                            @endif
+                            @if ($phone['visible'] ?? false)
+                                <li>Telepon: <a href="tel:{{ preg_replace('/[^0-9+]/', '', $phone['text']) }}">{{ $phone['text'] }}</a></li>
+                            @endif
+                            @if ($email['visible'] ?? false)
+                                <li>Email: <a href="mailto:{{ $email['text'] }}">{{ $email['text'] }}</a></li>
+                            @endif
+                        </ul>
                     </div>
                 </div>
-            </div>
+            @endif
+            @if ($showHotlinks && count($links))
+                <div class="col-lg-4 col-md-6 col-sm-6">
+                    <div class="footer__widget">
+                        <h6>Hot Links</h6>
+                        <ul>
+                            @foreach ($links as $link)
+                                <li><a href="{{ $link['href'] }}">{{ $link['label'] }}</a></li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </div>
+            @endif
+            @if (($social['visible'] ?? false) || ($schedule['visible'] ?? false))
+                <div class="col-lg-4 col-md-12">
+                    <div class="footer__widget">
+                        @if ($schedule['visible'] ?? false)
+                            <h6>Jam Operasional</h6>
+                            <p>{{ $schedule['text'] }}</p>
+                        @endif
+                        @if ($social['visible'] ?? false)
+                            <div class="footer__widget__social mt-3">
+                                <a href="{{ $social['text'] }}" target="_blank" rel="noopener"><i class="fa fa-instagram"></i></a>
+                            </div>
+                        @endif
+                    </div>
+                </div>
+            @endif
         </div>
-        <div class="row">
+        <div class="row mt-4">
             <div class="col-lg-12">
-                <div class="footer__copyright">
-                    <div class="footer__copyright__text"><p>{{ $settings['footer.copyright'] ?? 'Copyright &copy; '.date('Y').' All rights reserved' }}@if(($settings['footer.privacy'] ?? '0') == '1') | <a href="#">Privacy Policy</a>@endif @if(($settings['footer.terms'] ?? '0') == '1') | <a href="#">Terms & Conditions</a>@endif</p></div>
-                    <div class="footer__copyright__payment"><img src="{{ asset('storage/themes/theme-second/img/payment-item.png') }}" alt=""></div>
+                <div class="footer__copyright text-center">
+                    @if (!empty($copyright))
+                        <div class="footer__copyright__text"><p>{{ $copyright }}</p></div>
+                    @endif
                 </div>
             </div>
         </div>

--- a/themes/theme-second/views/components/nav-menu.blade.php
+++ b/themes/theme-second/views/components/nav-menu.blade.php
@@ -1,12 +1,25 @@
 @php
     $cartSummary = $cart ?? ['total_quantity' => 0, 'total_price_formatted' => '0'];
+    $brand = $brand ?? ['visible' => true, 'label' => 'Ogani Store', 'logo' => null, 'url' => url('/')];
+    $links = $links ?? [];
+    $showCart = $showCart ?? true;
+    $showLogin = $showLogin ?? false;
+    $showIcons = $showCart || $showLogin;
 @endphp
-<header class="header">
+<header id="navigation" class="header">
     <div class="container">
         <div class="row">
             <div class="col-lg-3">
                 <div class="header__logo">
-                    <a href="{{ url('/') }}"><img src="{{ asset('storage/themes/theme-second/img/logo.png') }}" alt=""></a>
+                    @if ($brand['visible'])
+                        <a href="{{ $brand['url'] ?? url('/') }}" class="d-inline-flex align-items-center gap-2 text-decoration-none">
+                            @if (!empty($brand['logo']))
+                                <img src="{{ $brand['logo'] }}" alt="{{ $brand['label'] }}" style="max-height: 48px; width: auto;">
+                            @else
+                                <span class="fw-bold fs-4 text-success">{{ $brand['label'] }}</span>
+                            @endif
+                        </a>
+                    @endif
                 </div>
             </div>
             <div class="col-lg-6">
@@ -21,13 +34,28 @@
                 </nav>
             </div>
             <div class="col-lg-3">
-                <div class="header__cart">
-                    <ul>
-                        <li><a href="#"><i class="fa fa-heart"></i> <span>0</span></a></li>
-                        <li><a href="{{ route('cart.index') }}" class="cart-indicator"><i class="fa fa-shopping-bag"></i> <span class="cart-count" data-cart-count data-count="{{ $cartSummary['total_quantity'] ?? 0 }}">{{ $cartSummary['total_quantity'] ?? 0 }}</span></a></li>
-                    </ul>
-                    <div class="header__cart__price">item: <span data-cart-total>{{ $cartSummary['total_price_formatted'] ?? '0' }}</span></div>
-                </div>
+                @if ($showIcons)
+                    <div class="header__cart d-flex justify-content-end align-items-center gap-3">
+                        @if ($showLogin)
+                            <div class="header__cart__login">
+                                @auth
+                                    <a href="{{ route('orders.index') }}" class="text-decoration-none fw-semibold">Akun Saya</a>
+                                @else
+                                    <a href="{{ route('login') }}" class="text-decoration-none fw-semibold">Login</a>
+                                @endauth
+                            </div>
+                        @endif
+                        @if ($showCart)
+                            <div>
+                                <a href="{{ route('cart.index') }}" class="cart-indicator d-inline-flex align-items-center text-decoration-none">
+                                    <i class="fa fa-shopping-bag me-1"></i>
+                                    <span class="cart-count" data-cart-count data-count="{{ $cartSummary['total_quantity'] ?? 0 }}">{{ $cartSummary['total_quantity'] ?? 0 }}</span>
+                                </a>
+                                <div class="header__cart__price">item: <span data-cart-total>{{ $cartSummary['total_price_formatted'] ?? '0' }}</span></div>
+                            </div>
+                        @endif
+                    </div>
+                @endif
             </div>
         </div>
         <div class="humberger__open">

--- a/themes/theme-second/views/home.blade.php
+++ b/themes/theme-second/views/home.blade.php
@@ -21,20 +21,24 @@
     use App\Models\PageSetting;
     use App\Models\Product;
     use App\Support\Cart;
-    $settings = PageSetting::where('theme', 'theme-second')->where('page', 'home')->pluck('value', 'key')->toArray();
+    use App\Support\LayoutSettings;
+    $themeName = $theme ?? 'theme-second';
+    $settings = PageSetting::where('theme', $themeName)->where('page', 'home')->pluck('value', 'key')->toArray();
     $products = Product::where('is_featured', true)->latest()->take(5)->get();
     $testimonials = json_decode($settings['testimonials.items'] ?? '[]', true);
     $services = json_decode($settings['services.items'] ?? '[]', true);
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => '#hero', 'visible' => ($settings['navigation.home'] ?? '1') == '1'],
-        ['label' => 'Tea Collection', 'href' => '#products', 'visible' => ($settings['navigation.products'] ?? '1') == '1'],
-        ['label' => 'News', 'href' => '#testimonials', 'visible' => ($settings['navigation.news'] ?? '1') == '1'],
-        ['label' => 'Contact Us', 'href' => '#contact', 'visible' => ($settings['navigation.contact'] ?? '1') == '1'],
-    ];
     $aboutImage = $settings['about.image'] ?? null;
     $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
 @endphp
-{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 @if(($settings['hero.visible'] ?? '1') == '1')
 <section id="hero" class="hero">
@@ -207,7 +211,9 @@
 </section>
 @endif
 
-{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 
 <script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
 <script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>

--- a/themes/theme-second/views/order.blade.php
+++ b/themes/theme-second/views/order.blade.php
@@ -112,16 +112,23 @@
 </head>
 <body>
 @php
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+
+    $themeName = $theme ?? 'theme-second';
     $orders = $orders ?? collect();
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-        ['label' => 'Pesanan', 'href' => url('/pesanan'), 'visible' => true],
-    ];
+    $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
 @endphp
 
-{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => App\Support\Cart::summary()])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 <section class="breadcrumb-section set-bg" data-setbg="{{ asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
     <div class="container">
@@ -234,7 +241,9 @@
     </div>
 </section>
 
-{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'))->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 
 <script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
 <script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>

--- a/themes/theme-second/views/payment.blade.php
+++ b/themes/theme-second/views/payment.blade.php
@@ -37,15 +37,11 @@
 </head>
 <body>
 @php
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
-    $footerLinks = [
-        ['label' => 'Privacy Policy', 'href' => '#', 'visible' => true],
-        ['label' => 'Terms & Conditions', 'href' => '#', 'visible' => true],
-    ];
+    use App\Support\LayoutSettings;
+
+    $themeName = $theme ?? 'theme-second';
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
     $items = $cartSummary['items'] ?? [];
     $instructions = $checkoutData['instructions'] ?? [];
     $publicConfig = $checkoutData['publicConfig'] ?? [];
@@ -54,7 +50,13 @@
     $feedbackType = $feedbackStatus['type'] ?? null;
 @endphp
 
-{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 <section class="checkout__section">
     <div class="container">
@@ -130,7 +132,9 @@
     </div>
 </section>
 
-{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), ['links' => $footerLinks])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 
 <script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
 <script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>

--- a/themes/theme-second/views/product-detail.blade.php
+++ b/themes/theme-second/views/product-detail.blade.php
@@ -30,14 +30,13 @@
     use App\Models\PageSetting;
     use App\Models\Product;
     use App\Support\Cart;
+    use App\Support\LayoutSettings;
 
-    $settings = PageSetting::where('theme', 'theme-second')->where('page', 'product-detail')->pluck('value', 'key')->toArray();
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
+    $themeName = $theme ?? 'theme-second';
+    $settings = PageSetting::where('theme', $themeName)->where('page', 'product-detail')->pluck('value', 'key')->toArray();
     $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
 
     $images = $product->images ?? collect();
     $imageSources = $images->pluck('path')->filter()->map(fn($path) => asset('storage/'.$path))->values();
@@ -61,7 +60,13 @@
         $recommendations = $recommendations->concat($fallback);
     }
 @endphp
-{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 
 <section class="breadcrumb-section set-bg" data-setbg="{{ !empty($settings['hero.image']) ? asset('storage/'.$settings['hero.image']) : asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
     <div class="container">
@@ -213,7 +218,9 @@
 </section>
 @endif
 
-{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 
 <script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
 <script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>

--- a/themes/theme-second/views/product.blade.php
+++ b/themes/theme-second/views/product.blade.php
@@ -19,7 +19,9 @@
     use App\Models\Product;
     use App\Models\Category;
     use App\Support\Cart;
-    $settings = PageSetting::where('theme', 'theme-second')->where('page', 'product')->pluck('value', 'key')->toArray();
+    use App\Support\LayoutSettings;
+    $themeName = $theme ?? 'theme-second';
+    $settings = PageSetting::where('theme', $themeName)->where('page', 'product')->pluck('value', 'key')->toArray();
     $query = Product::query();
     if($s = request('search')){ $query->where('name','like',"%$s%"); }
     if($cat = request('category')){ $query->whereHas('categories', fn($q)=>$q->where('slug',$cat)); }
@@ -32,14 +34,17 @@
     }
     $products = $query->paginate(15)->withQueryString();
     $categories = Category::all();
-    $navLinks = [
-        ['label' => 'Homepage', 'href' => url('/'), 'visible' => true],
-        ['label' => 'Produk', 'href' => url('/produk'), 'visible' => true],
-        ['label' => 'Keranjang', 'href' => url('/keranjang'), 'visible' => true],
-    ];
     $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
 @endphp
-{!! view()->file(base_path('themes/theme-second/views/components/nav-menu.blade.php'), ['links' => $navLinks, 'cart' => $cartSummary])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
 <section class="breadcrumb-section set-bg" data-setbg="{{ !empty($settings['hero.image']) ? asset('storage/'.$settings['hero.image']) : asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
     <div class="container">
         <div class="row">
@@ -159,7 +164,9 @@
         </div>
     </div>
 </section>
-{!! view()->file(base_path('themes/theme-second/views/components/footer.blade.php'), ['settings' => $settings])->render() !!}
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
 <script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
 <script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>
 <script src="{{ asset('storage/themes/theme-second/js/jquery.nice-select.min.js') }}"></script>


### PR DESCRIPTION
## Summary
- add theme-specific default brand labels when navigation settings are unset
- update Restoran and Ogani themes to source header and footer content from the centralized layout settings, including new brand/login/cart toggles
- refresh footer partials in both themes to respect admin-configurable contact, hot link, social, and schedule visibility

## Testing
- not run (tests not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5146b0fa48329abf8e8d2b82ebb1d