### PR TITLE
Add configurable Tentang Kami pages across themes

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -205,6 +205,96 @@ class PageController extends Controller
         return response()->json(['status' => 'ok']);
     }
 
+    public function about()
+    {
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+        $settings = PageSetting::where('theme', $theme)
+            ->where('page', 'about')
+            ->pluck('value', 'key');
+
+        $sections = [
+            'hero' => [
+                'label' => 'Header',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Seksi', 'id' => 'hero.visible'],
+                    ['type' => 'image', 'label' => 'Gambar Latar', 'id' => 'hero.background'],
+                    ['type' => 'text', 'label' => 'Judul', 'id' => 'hero.heading'],
+                    ['type' => 'textarea', 'label' => 'Deskripsi Singkat', 'id' => 'hero.text'],
+                ],
+            ],
+            'intro' => [
+                'label' => 'Tentang Kami',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Seksi', 'id' => 'intro.visible'],
+                    ['type' => 'image', 'label' => 'Gambar', 'id' => 'intro.image'],
+                    ['type' => 'text', 'label' => 'Judul Seksi', 'id' => 'intro.heading'],
+                    ['type' => 'textarea', 'label' => 'Deskripsi', 'id' => 'intro.description'],
+                ],
+            ],
+            'quote' => [
+                'label' => 'Quote',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Seksi', 'id' => 'quote.visible'],
+                    ['type' => 'textarea', 'label' => 'Teks Quote', 'id' => 'quote.text'],
+                    ['type' => 'text', 'label' => 'Nama Pengutip', 'id' => 'quote.author'],
+                ],
+            ],
+            'team' => [
+                'label' => 'Tim Kami',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Seksi', 'id' => 'team.visible'],
+                    ['type' => 'text', 'label' => 'Judul Seksi', 'id' => 'team.heading'],
+                    ['type' => 'textarea', 'label' => 'Deskripsi Pendek', 'id' => 'team.description'],
+                    ['type' => 'repeatable', 'id' => 'team.members', 'fields' => [
+                        ['name' => 'name', 'placeholder' => 'Nama'],
+                        ['name' => 'title', 'placeholder' => 'Jabatan'],
+                        ['name' => 'photo', 'placeholder' => 'Path Foto'],
+                        ['name' => 'description', 'placeholder' => 'Deskripsi', 'type' => 'textarea'],
+                    ]],
+                ],
+            ],
+            'advantages' => [
+                'label' => 'Keunggulan Kami',
+                'elements' => [
+                    ['type' => 'checkbox', 'label' => 'Tampilkan Seksi', 'id' => 'advantages.visible'],
+                    ['type' => 'text', 'label' => 'Judul Seksi', 'id' => 'advantages.heading'],
+                    ['type' => 'textarea', 'label' => 'Deskripsi Pendek', 'id' => 'advantages.description'],
+                    ['type' => 'repeatable', 'id' => 'advantages.items', 'fields' => [
+                        ['name' => 'icon', 'placeholder' => 'Kelas Ikon (contoh: fa fa-leaf)'],
+                        ['name' => 'title', 'placeholder' => 'Judul Keunggulan'],
+                        ['name' => 'text', 'placeholder' => 'Deskripsi', 'type' => 'textarea'],
+                    ]],
+                ],
+            ],
+        ];
+
+        $previewUrl = route('about');
+
+        return view('admin.pages.about', compact('sections', 'settings', 'previewUrl'));
+    }
+
+    public function updateAbout(Request $request)
+    {
+        $request->validate([
+            'key' => 'required',
+            'value' => 'nullable',
+        ]);
+
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+
+        $value = $request->input('value');
+        if ($request->hasFile('value')) {
+            $value = $request->file('value')->store("pages/{$theme}", 'public');
+        }
+
+        PageSetting::updateOrCreate(
+            ['theme' => $theme, 'page' => 'about', 'key' => $request->input('key')],
+            ['value' => $value]
+        );
+
+        return response()->json(['status' => 'ok']);
+    }
+
     public function cart()
     {
         $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
@@ -277,6 +367,7 @@ class PageController extends Controller
                     ['type' => 'text', 'label' => 'Nama Brand', 'id' => 'navigation.brand.text'],
                     ['type' => 'image', 'label' => 'Logo Brand', 'id' => 'navigation.brand.logo'],
                     ['type' => 'checkbox', 'label' => 'Tautan Home', 'id' => 'navigation.link.home'],
+                    ['type' => 'checkbox', 'label' => 'Tautan Tentang Kami', 'id' => 'navigation.link.about'],
                     ['type' => 'checkbox', 'label' => 'Tautan Produk', 'id' => 'navigation.link.products'],
                     ['type' => 'checkbox', 'label' => 'Tautan Pesanan Saya', 'id' => 'navigation.link.orders'],
                     ['type' => 'checkbox', 'label' => 'Ikon Keranjang', 'id' => 'navigation.icon.cart'],

--- a/app/Support/LayoutSettings.php
+++ b/app/Support/LayoutSettings.php
@@ -45,6 +45,12 @@ class LayoutSettings
                 'visible' => ($settings['navigation.link.home'] ?? '1') === '1',
             ],
             [
+                'key' => 'about',
+                'label' => 'Tentang Kami',
+                'href' => route('about'),
+                'visible' => ($settings['navigation.link.about'] ?? '1') === '1',
+            ],
+            [
                 'key' => 'products',
                 'label' => 'Produk',
                 'href' => route('products.index'),

--- a/resources/views/admin/pages/about.blade.php
+++ b/resources/views/admin/pages/about.blade.php
@@ -1,0 +1,170 @@
+@extends('layout.admin')
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="row">
+      <div class="col-md-4" id="elements" style="max-height:100vh; overflow-y:auto;">
+        @foreach ($sections as $key => $section)
+        <div class="card mb-3" data-section="{{ $key }}">
+          <div class="card-header">{{ $section['label'] }}</div>
+          <div class="card-body">
+            @foreach ($section['elements'] as $element)
+              <div class="form-group">
+                @if ($element['type'] === 'checkbox')
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" data-key="{{ $element['id'] }}" {{ ($settings[$element['id']] ?? '1') == '1' ? 'checked' : '' }}>
+                    <label class="form-check-label">{{ $element['label'] }}</label>
+                  </div>
+                @elseif ($element['type'] === 'text')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="text" class="form-control" data-key="{{ $element['id'] }}" value="{{ $settings[$element['id']] ?? '' }}">
+                @elseif ($element['type'] === 'textarea')
+                  <label>{{ $element['label'] }}</label>
+                  <textarea class="form-control" data-key="{{ $element['id'] }}">{{ $settings[$element['id']] ?? '' }}</textarea>
+                @elseif ($element['type'] === 'image')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="file" class="form-control-file" data-key="{{ $element['id'] }}">
+                  @if (!empty($settings[$element['id']]))
+                    <img src="{{ asset('storage/' . $settings[$element['id']]) }}" alt="Preview" class="img-fluid mt-2 rounded" style="max-height:120px; object-fit:contain;">
+                  @endif
+                @elseif ($element['type'] === 'repeatable')
+                  @php
+                    $items = json_decode($settings[$element['id']] ?? '[]', true);
+                    $fields = $element['fields'] ?? [];
+                  @endphp
+                  <div data-repeatable="{{ $element['id'] }}" data-fields='@json($fields)'>
+                    <div class="repeatable-items"></div>
+                    <button type="button" class="btn btn-sm btn-secondary add-item">Tambah Item</button>
+                    <textarea class="d-none" data-key="{{ $element['id'] }}">{{ json_encode($items) }}</textarea>
+                  </div>
+                @endif
+              </div>
+            @endforeach
+          </div>
+        </div>
+        @endforeach
+      </div>
+      <div class="col-md-8 position-sticky" style="top:0;height:100vh">
+        <iframe id="page-preview" src="{{ $previewUrl }}" class="w-100 border h-100"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+const csrf = '{{ csrf_token() }}';
+
+function debounce(fn, delay) {
+  let timer;
+  return function(...args) {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn.apply(this, args), delay);
+  }
+}
+
+const triggerPreviewReload = debounce(function(){
+  const iframe = document.getElementById('page-preview');
+  iframe.contentWindow.location.reload();
+}, 500);
+
+document.querySelectorAll('#elements [data-key]').forEach(function(input){
+  input.addEventListener('change', function(){
+    const key = this.getAttribute('data-key');
+    const formData = new FormData();
+    formData.append('key', key);
+    if(this.type === 'checkbox'){
+      formData.append('value', this.checked ? 1 : 0);
+    }else if(this.type === 'file'){
+      if(this.files[0]){ formData.append('value', this.files[0]); }
+    }else{
+      formData.append('value', this.value);
+    }
+    fetch('{{ route('admin.pages.about.update') }}', {
+      method: 'POST',
+      headers: {'X-CSRF-TOKEN': csrf},
+      body: formData
+    }).then(() => {
+      triggerPreviewReload();
+    });
+  });
+});
+
+document.querySelectorAll('[data-repeatable]').forEach(function(wrapper){
+  const itemsContainer = wrapper.querySelector('.repeatable-items');
+  const hidden = wrapper.querySelector('[data-key]');
+  const fields = JSON.parse(wrapper.getAttribute('data-fields') || '[]');
+
+  function buildItem(data = {}){
+    const div = document.createElement('div');
+    div.className = 'repeatable-item mb-2 p-2 border rounded';
+    let html = '';
+    fields.forEach(function(field){
+      const fieldType = field.type || 'text';
+      if(fieldType === 'textarea'){
+        html += `<textarea class="form-control mb-1" data-field="${field.name}" placeholder="${field.placeholder}">${data[field.name] || ''}</textarea>`;
+      }else{
+        html += `<input type="text" class="form-control mb-1" data-field="${field.name}" placeholder="${field.placeholder}" value="${data[field.name] || ''}">`;
+      }
+    });
+    html += '<button type="button" class="btn btn-sm btn-danger remove-item">Hapus</button>';
+    div.innerHTML = html;
+    return div;
+  }
+
+  function sync(){
+    const data = [];
+    itemsContainer.querySelectorAll('.repeatable-item').forEach(function(item){
+      const obj = {};
+      item.querySelectorAll('[data-field]').forEach(function(input){
+        obj[input.getAttribute('data-field')] = input.value;
+      });
+      data.push(obj);
+    });
+    hidden.value = JSON.stringify(data);
+    hidden.dispatchEvent(new Event('change'));
+  }
+
+  wrapper.querySelector('.add-item').addEventListener('click', function(){
+    itemsContainer.appendChild(buildItem());
+  });
+
+  itemsContainer.addEventListener('input', sync);
+  itemsContainer.addEventListener('click', function(e){
+    if(e.target.classList.contains('remove-item')){
+      e.target.closest('.repeatable-item').remove();
+      sync();
+    }
+  });
+
+  try {
+    JSON.parse(hidden.value || '[]').forEach(function(item){
+      itemsContainer.appendChild(buildItem(item));
+    });
+  } catch(e) {}
+  sync();
+});
+
+document.querySelectorAll('#elements .card').forEach(function(card){
+  card.addEventListener('mouseenter', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '2px dashed #ff9800';
+      section.scrollIntoView({behavior:'smooth'});
+    }
+  });
+  card.addEventListener('mouseleave', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    const section = iframe.contentWindow.document.getElementById(target);
+    if(section){
+      section.style.outline = '';
+    }
+  });
+});
+</script>
+@endsection

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -116,6 +116,7 @@
               <ul class="nav flex-column sub-menu">
                 <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/layout')}}">Navigasi & Footer</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/home')}}">Home</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/about')}}">Tentang Kami</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/product')}}">Produk</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/product-detail')}}">Detail Produk</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{url('/admin/pages/cart')}}">Keranjang</a></li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,15 @@ Route::get('/produk', function () {
     abort(404);
 })->name('products.index');
 
+Route::get('/tentang-kami', function () {
+    $activeTheme = Setting::getValue('active_theme', 'theme-herbalgreen');
+    $viewPath = base_path("themes/{$activeTheme}/views/tentang-kami.blade.php");
+    if (File::exists($viewPath)) {
+        return view()->file($viewPath, ['theme' => $activeTheme]);
+    }
+    abort(404);
+})->name('about');
+
 Route::get('/produk/{product}', function (Product $product) {
     $activeTheme = Setting::getValue('active_theme', 'theme-herbalgreen');
     $viewPath = base_path("themes/{$activeTheme}/views/product-detail.blade.php");
@@ -138,6 +147,8 @@ Route::prefix('admin')->middleware(['auth'])->group(function () {
 
         Route::get('pages/home', [PageController::class, 'home'])->name('admin.pages.home');
         Route::post('pages/home', [PageController::class, 'updateHome'])->name('admin.pages.home.update');
+        Route::get('pages/about', [PageController::class, 'about'])->name('admin.pages.about');
+        Route::post('pages/about', [PageController::class, 'updateAbout'])->name('admin.pages.about.update');
         Route::get('pages/product', [PageController::class, 'product'])->name('admin.pages.product');
         Route::post('pages/product', [PageController::class, 'updateProduct'])->name('admin.pages.product.update');
         Route::get('pages/product-detail', [PageController::class, 'productDetail'])->name('admin.pages.product-detail');

--- a/themes/theme-herbalgreen/assets/theme.css
+++ b/themes/theme-herbalgreen/assets/theme.css
@@ -187,3 +187,102 @@ footer {
   background-color: var(--color-primary);
   color: #fff;
 }
+
+.about-hero {
+  background-size: cover;
+  background-position: center;
+  min-height: 45vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.about-intro {
+  padding: 4rem 2rem;
+}
+
+.about-intro__grid {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.about-intro__image img {
+  width: 100%;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+.about-quote {
+  background: #e8f5e9;
+  padding: 3rem 2rem;
+  text-align: center;
+  font-style: italic;
+}
+
+.about-quote blockquote {
+  margin: 0 auto;
+  max-width: 720px;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.about-team__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.about-team__card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 2rem 1.5rem;
+  text-align: center;
+  box-shadow: 0 10px 30px rgba(17, 97, 45, 0.12);
+}
+
+.about-team__photo {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 1rem;
+}
+
+.about-team__role {
+  display: block;
+  color: var(--color-secondary);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.about-advantages__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.about-advantages__item {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.75rem;
+  box-shadow: 0 10px 30px rgba(17, 97, 45, 0.08);
+  text-align: center;
+}
+
+.about-advantages__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--color-secondary);
+  color: var(--color-text);
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}

--- a/themes/theme-herbalgreen/views/tentang-kami.blade.php
+++ b/themes/theme-herbalgreen/views/tentang-kami.blade.php
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tentang Kami - Herbal Green</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+    <script src="{{ asset('themes/' . $theme . '/theme.js') }}" defer></script>
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+    use Illuminate\Support\Str;
+
+    $themeName = $theme ?? 'theme-herbalgreen';
+    $settings = PageSetting::where('theme', $themeName)->where('page', 'about')->pluck('value', 'key')->toArray();
+    $teamMembers = json_decode($settings['team.members'] ?? '[]', true);
+    $advantages = json_decode($settings['advantages.items'] ?? '[]', true);
+    if (!is_array($teamMembers)) {
+        $teamMembers = [];
+    }
+    if (!is_array($advantages)) {
+        $advantages = [];
+    }
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
+    $cartSummary = Cart::summary();
+
+    $resolveMedia = function (?string $value) {
+        if (! $value) {
+            return null;
+        }
+        if (Str::startsWith($value, ['http://', 'https://', '//'])) {
+            return $value;
+        }
+        return asset('storage/' . ltrim($value, '/'));
+    };
+@endphp
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
+
+@if(($settings['hero.visible'] ?? '1') == '1')
+<section id="hero" class="hero about-hero" @if(!empty($settings['hero.background'])) style="background-image:url('{{ $resolveMedia($settings['hero.background']) }}')" @endif>
+    <div class="hero-content">
+        <h1>{{ $settings['hero.heading'] ?? 'Tentang Kami' }}</h1>
+        @if(!empty($settings['hero.text']))
+        <p>{{ $settings['hero.text'] }}</p>
+        @endif
+    </div>
+</section>
+@endif
+
+@if(($settings['intro.visible'] ?? '1') == '1')
+<section id="intro" class="about-intro">
+    <div class="about-intro__grid">
+        <div class="about-intro__image">
+            @php $image = $resolveMedia($settings['intro.image'] ?? null); @endphp
+            @if($image)
+                <img src="{{ $image }}" alt="{{ $settings['intro.heading'] ?? 'Tentang Kami' }}">
+            @endif
+        </div>
+        <div class="about-intro__content">
+            <h2>{{ $settings['intro.heading'] ?? 'Perjalanan Kami' }}</h2>
+            <p>{{ $settings['intro.description'] ?? 'Kami percaya pada kekuatan alam untuk menghadirkan kehidupan yang lebih sehat dan seimbang.' }}</p>
+        </div>
+    </div>
+</section>
+@endif
+
+@if(($settings['quote.visible'] ?? '1') == '1' && !empty($settings['quote.text']))
+<section id="quote" class="about-quote">
+    <blockquote>
+        <p>“{{ $settings['quote.text'] }}”</p>
+        @if(!empty($settings['quote.author']))
+        <cite>— {{ $settings['quote.author'] }}</cite>
+        @endif
+    </blockquote>
+</section>
+@endif
+
+@if(($settings['team.visible'] ?? '1') == '1' && count($teamMembers))
+<section id="team" class="about-team">
+    <div class="section-header">
+        <h2>{{ $settings['team.heading'] ?? 'Tim Kami' }}</h2>
+        @if(!empty($settings['team.description']))
+        <p>{{ $settings['team.description'] }}</p>
+        @endif
+    </div>
+    <div class="about-team__grid">
+        @foreach($teamMembers as $member)
+            <div class="about-team__card">
+                @php $photo = $resolveMedia($member['photo'] ?? null); @endphp
+                @if($photo)
+                <img src="{{ $photo }}" alt="{{ $member['name'] ?? '' }}" class="about-team__photo">
+                @endif
+                <h3>{{ $member['name'] ?? '' }}</h3>
+                <span class="about-team__role">{{ $member['title'] ?? '' }}</span>
+                @if(!empty($member['description']))
+                <p>{{ $member['description'] }}</p>
+                @endif
+            </div>
+        @endforeach
+    </div>
+</section>
+@endif
+
+@if(($settings['advantages.visible'] ?? '1') == '1' && count($advantages))
+<section id="advantages" class="about-advantages">
+    <div class="section-header">
+        <h2>{{ $settings['advantages.heading'] ?? 'Keunggulan Kami' }}</h2>
+        @if(!empty($settings['advantages.description']))
+        <p>{{ $settings['advantages.description'] }}</p>
+        @endif
+    </div>
+    <div class="about-advantages__grid">
+        @foreach($advantages as $advantage)
+            <div class="about-advantages__item">
+                @if(!empty($advantage['icon']))
+                <span class="about-advantages__icon"><i class="{{ $advantage['icon'] }}"></i></span>
+                @endif
+                <h3>{{ $advantage['title'] ?? '' }}</h3>
+                <p>{{ $advantage['text'] ?? '' }}</p>
+            </div>
+        @endforeach
+    </div>
+</section>
+@endif
+
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+</body>
+</html>

--- a/themes/theme-restoran/views/tentang-kami.blade.php
+++ b/themes/theme-restoran/views/tentang-kami.blade.php
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Tentang Kami - Restoran Theme</title>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="" name="keywords">
+    <meta content="" name="description">
+    <link href="{{ asset('storage/themes/theme-restoran/img/favicon.ico') }}" rel="icon">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600&family=Nunito:wght@600;700;800&family=Pacifico&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.0/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/animate/animate.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/assets/owl.carousel.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/css/tempusdominus-bootstrap-4.min.css') }}" rel="stylesheet" />
+    <link href="{{ asset('storage/themes/theme-restoran/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/css/style.css') }}" rel="stylesheet">
+    <style>
+        :root{--bs-primary:#FEA116;--bs-primary-rgb:254,161,22;}
+        .navbar {position: sticky; top:0; z-index:1030;}
+        .hero-header {background-size: cover; background-position: center;}
+    </style>
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+    use Illuminate\Support\Str;
+
+    $themeName = $theme ?? 'theme-restoran';
+    $settings = PageSetting::where('theme', $themeName)->where('page', 'about')->pluck('value', 'key')->toArray();
+    $teamMembers = json_decode($settings['team.members'] ?? '[]', true);
+    $advantages = json_decode($settings['advantages.items'] ?? '[]', true);
+    if (!is_array($teamMembers)) {
+        $teamMembers = [];
+    }
+    if (!is_array($advantages)) {
+        $advantages = [];
+    }
+    $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
+
+    $resolveMedia = function (?string $value) {
+        if (! $value) {
+            return null;
+        }
+        if (Str::startsWith($value, ['http://', 'https://', '//'])) {
+            return $value;
+        }
+        return asset('storage/' . ltrim($value, '/'));
+    };
+@endphp
+<div class="container-xxl position-relative p-0">
+    {!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+        'brand' => $navigation['brand'],
+        'links' => $navigation['links'],
+        'showCart' => $navigation['show_cart'],
+        'showLogin' => $navigation['show_login'],
+        'cart' => $cartSummary,
+    ])->render() !!}
+    @if(($settings['hero.visible'] ?? '1') == '1')
+    <div id="hero" class="container-xxl py-5 bg-dark hero-header mb-5" @if(!empty($settings['hero.background'])) style="background-image:url('{{ $resolveMedia($settings['hero.background']) }}')" @endif>
+        <div class="container text-center my-5 pt-5 pb-4">
+            <h1 class="display-4 text-white mb-3">{{ $settings['hero.heading'] ?? 'Tentang Kami' }}</h1>
+            @if(!empty($settings['hero.text']))
+            <p class="text-white-50 mb-0">{{ $settings['hero.text'] }}</p>
+            @endif
+        </div>
+    </div>
+    @endif
+</div>
+
+@if(($settings['intro.visible'] ?? '1') == '1')
+<div id="intro" class="container-xxl py-5">
+    <div class="container">
+        <div class="row g-5 align-items-center">
+            <div class="col-lg-6">
+                @php $image = $resolveMedia($settings['intro.image'] ?? null); @endphp
+                <div class="position-relative">
+                    <img class="img-fluid rounded w-100" src="{{ $image ?: asset('storage/themes/theme-restoran/img/about-1.jpg') }}" alt="{{ $settings['intro.heading'] ?? 'Tentang Kami' }}">
+                    <span class="position-absolute top-0 start-0 translate-middle badge rounded-pill bg-primary px-3 py-2">{{ $settings['hero.heading'] ?? 'Tentang Kami' }}</span>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <h5 class="section-title ff-secondary text-start text-primary fw-normal">{{ $settings['intro.heading'] ?? 'Cerita Kami' }}</h5>
+                <p class="mb-4">{{ $settings['intro.description'] ?? 'Kami menyajikan pengalaman kuliner terbaik dengan bahan pilihan dan layanan penuh kehangatan.' }}</p>
+            </div>
+        </div>
+    </div>
+</div>
+@endif
+
+@if(($settings['quote.visible'] ?? '1') == '1' && !empty($settings['quote.text']))
+<div id="quote" class="container-xxl py-5 bg-dark">
+    <div class="container text-center">
+        <div class="mx-auto" style="max-width:720px;">
+            <i class="fa fa-quote-left fa-2x text-primary mb-3"></i>
+            <p class="fs-4 text-white-50">“{{ $settings['quote.text'] }}”</p>
+            @if(!empty($settings['quote.author']))
+            <h5 class="text-white mb-0">{{ $settings['quote.author'] }}</h5>
+            @endif
+        </div>
+    </div>
+</div>
+@endif
+
+@if(($settings['team.visible'] ?? '1') == '1' && count($teamMembers))
+<div id="team" class="container-xxl pt-5 pb-3">
+    <div class="container">
+        <div class="text-center">
+            <h5 class="section-title ff-secondary text-center text-primary fw-normal">{{ $settings['team.heading'] ?? 'Tim Kami' }}</h5>
+            @if(!empty($settings['team.description']))
+            <p class="text-muted mb-5">{{ $settings['team.description'] }}</p>
+            @endif
+        </div>
+        <div class="row g-4">
+            @foreach($teamMembers as $index => $member)
+            @php $photo = $resolveMedia($member['photo'] ?? null); @endphp
+            <div class="col-lg-3 col-md-6">
+                <div class="team-item text-center rounded overflow-hidden h-100">
+                    <div class="rounded-circle overflow-hidden m-4">
+                        <img class="img-fluid" src="{{ $photo ?: asset('storage/themes/theme-restoran/img/team-' . (($index % 4) + 1) . '.jpg') }}" alt="{{ $member['name'] ?? '' }}">
+                    </div>
+                    <h5 class="mb-0">{{ $member['name'] ?? '' }}</h5>
+                    <small>{{ $member['title'] ?? '' }}</small>
+                    @if(!empty($member['description']))
+                    <p class="px-3 mt-3 mb-0">{{ $member['description'] }}</p>
+                    @endif
+                </div>
+            </div>
+            @endforeach
+        </div>
+    </div>
+</div>
+@endif
+
+@if(($settings['advantages.visible'] ?? '1') == '1' && count($advantages))
+<div id="advantages" class="container-xxl py-5">
+    <div class="container">
+        <div class="text-center mb-5">
+            <h5 class="section-title ff-secondary text-center text-primary fw-normal">{{ $settings['advantages.heading'] ?? 'Keunggulan Kami' }}</h5>
+            @if(!empty($settings['advantages.description']))
+            <p class="text-muted">{{ $settings['advantages.description'] }}</p>
+            @endif
+        </div>
+        <div class="row g-4">
+            @foreach($advantages as $advantage)
+            <div class="col-lg-4 col-md-6">
+                <div class="service-item rounded pt-3 h-100">
+                    <div class="p-4">
+                        @if(!empty($advantage['icon']))
+                        <i class="{{ $advantage['icon'] }} text-primary fa-3x mb-3"></i>
+                        @endif
+                        <h5>{{ $advantage['title'] ?? '' }}</h5>
+                        <p class="mb-0">{{ $advantage['text'] ?? '' }}</p>
+                    </div>
+                </div>
+            </div>
+            @endforeach
+        </div>
+    </div>
+</div>
+@endif
+
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/wow/wow.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/easing/easing.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/waypoints/waypoints.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/counterup/counterup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment-timezone.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/tempusdominus-bootstrap-4.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/js/main.js') }}"></script>
+</body>
+</html>

--- a/themes/theme-second/views/tentang-kami.blade.php
+++ b/themes/theme-second/views/tentang-kami.blade.php
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tentang Kami</title>
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/bootstrap.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/font-awesome.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/elegant-icons.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/nice-select.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/jquery-ui.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/owl.carousel.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/slicknav.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/style.css') }}" type="text/css">
+    <style>
+        .header {position: sticky; top: 0; z-index: 1000; background: #fff;}
+    </style>
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+    use Illuminate\Support\Str;
+
+    $themeName = $theme ?? 'theme-second';
+    $settings = PageSetting::where('theme', $themeName)->where('page', 'about')->pluck('value', 'key')->toArray();
+    $teamMembers = json_decode($settings['team.members'] ?? '[]', true);
+    $advantages = json_decode($settings['advantages.items'] ?? '[]', true);
+    if (!is_array($teamMembers)) {
+        $teamMembers = [];
+    }
+    if (!is_array($advantages)) {
+        $advantages = [];
+    }
+    $cartSummary = Cart::summary();
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
+
+    $resolveMedia = function (?string $value) {
+        if (! $value) {
+            return null;
+        }
+        if (Str::startsWith($value, ['http://', 'https://', '//'])) {
+            return $value;
+        }
+        return asset('storage/' . ltrim($value, '/'));
+    };
+@endphp
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
+
+@if(($settings['hero.visible'] ?? '1') == '1')
+<section id="hero" class="breadcrumb-section set-bg" data-setbg="{{ !empty($settings['hero.background']) ? $resolveMedia($settings['hero.background']) : asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <div class="breadcrumb__text">
+                    <h2>{{ $settings['hero.heading'] ?? 'Tentang Kami' }}</h2>
+                    @if(!empty($settings['hero.text']))
+                    <p>{{ $settings['hero.text'] }}</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endif
+
+@if(($settings['intro.visible'] ?? '1') == '1')
+<section id="intro" class="about spad">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-6 col-md-6">
+                <div class="about__pic">
+                    @php $image = $resolveMedia($settings['intro.image'] ?? null); @endphp
+                    <img src="{{ $image ?: asset('storage/themes/theme-second/img/about/about-1.jpg') }}" alt="{{ $settings['intro.heading'] ?? 'Tentang Kami' }}">
+                </div>
+            </div>
+            <div class="col-lg-6 col-md-6">
+                <div class="about__text">
+                    <h2>{{ $settings['intro.heading'] ?? 'Cerita Kami' }}</h2>
+                    <p>{{ $settings['intro.description'] ?? 'Kami berkomitmen menghadirkan produk segar dan layanan terbaik untuk keluarga Indonesia.' }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endif
+
+@if(($settings['quote.visible'] ?? '1') == '1' && !empty($settings['quote.text']))
+<section id="quote" class="testimonial spad">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <div class="testimonial__item text-center">
+                    <div class="testimonial__text">
+                        <p>“{{ $settings['quote.text'] }}”</p>
+                        @if(!empty($settings['quote.author']))
+                        <h5>{{ $settings['quote.author'] }}</h5>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endif
+
+@if(($settings['team.visible'] ?? '1') == '1' && count($teamMembers))
+<section id="team" class="team spad">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="section-title">
+                    <h2>{{ $settings['team.heading'] ?? 'Tim Kami' }}</h2>
+                    @if(!empty($settings['team.description']))
+                    <p>{{ $settings['team.description'] }}</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            @foreach($teamMembers as $index => $member)
+            @php $photo = $resolveMedia($member['photo'] ?? null); @endphp
+            <div class="col-lg-3 col-md-4 col-sm-6">
+                <div class="team__item">
+                    <div class="team__item__pic">
+                        <img src="{{ $photo ?: asset('storage/themes/theme-second/img/team/team-' . (($index % 4) + 1) . '.jpg') }}" alt="{{ $member['name'] ?? '' }}">
+                    </div>
+                    <div class="team__item__text">
+                        <h5>{{ $member['name'] ?? '' }}</h5>
+                        <span>{{ $member['title'] ?? '' }}</span>
+                        @if(!empty($member['description']))
+                        <p>{{ $member['description'] }}</p>
+                        @endif
+                    </div>
+                </div>
+            </div>
+            @endforeach
+        </div>
+    </div>
+</section>
+@endif
+
+@if(($settings['advantages.visible'] ?? '1') == '1' && count($advantages))
+<section id="advantages" class="services spad">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="section-title">
+                    <h2>{{ $settings['advantages.heading'] ?? 'Keunggulan Kami' }}</h2>
+                    @if(!empty($settings['advantages.description']))
+                    <p>{{ $settings['advantages.description'] }}</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            @foreach($advantages as $advantage)
+            <div class="col-lg-4 col-md-4 col-sm-6">
+                <div class="services__item">
+                    @if(!empty($advantage['icon']))
+                    <span class="icon"><i class="{{ $advantage['icon'] }}" aria-hidden="true"></i></span>
+                    @endif
+                    <h5>{{ $advantage['title'] ?? '' }}</h5>
+                    <p>{{ $advantage['text'] ?? '' }}</p>
+                </div>
+            </div>
+            @endforeach
+        </div>
+    </div>
+</section>
+@endif
+
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+<script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.nice-select.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery-ui.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.slicknav.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/mixitup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/main.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated Tentang Kami admin page with configurable sections and live preview
- expose Tentang Kami visibility controls in navigation management and register public routing
- implement Tentang Kami views for all bundled themes, including supporting styling for Herbal Green

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d88f5209f8832987b782ab0b0edcbe