### PR TITLE
Improve Restoran hero customization and branding options

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -21,6 +21,7 @@ class PageController extends Controller
                 'label' => 'Hero',
                 'elements' => [
                     ['type' => 'checkbox', 'label' => 'Show Section', 'id' => 'hero.visible'],
+                    ['type' => 'checkbox', 'label' => 'Use Dark Overlay', 'id' => 'hero.mask'],
                     ['type' => 'image', 'label' => 'Main Image', 'id' => 'hero.image'],
                     ['type' => 'image', 'label' => 'Spinning Image', 'id' => 'hero.spin_image'],
                     ['type' => 'text', 'label' => 'Spinning Text', 'id' => 'hero.spin_text'],
@@ -115,6 +116,7 @@ class PageController extends Controller
                 'label' => 'Hero',
                 'elements' => [
                     ['type' => 'checkbox', 'label' => 'Show Section', 'id' => 'hero.visible'],
+                    ['type' => 'checkbox', 'label' => 'Use Dark Overlay', 'id' => 'hero.mask'],
                     ['type' => 'image', 'label' => 'Background Image', 'id' => 'hero.image'],
                     ['type' => 'text', 'label' => 'Title', 'id' => 'title'],
                 ],
@@ -155,6 +157,7 @@ class PageController extends Controller
                 'label' => 'Hero',
                 'elements' => [
                     ['type' => 'checkbox', 'label' => 'Show Section', 'id' => 'hero.visible'],
+                    ['type' => 'checkbox', 'label' => 'Use Dark Overlay', 'id' => 'hero.mask'],
                     ['type' => 'image', 'label' => 'Background Image', 'id' => 'hero.image'],
                     ['type' => 'text', 'label' => 'Breadcrumb Title', 'id' => 'hero.title'],
                 ],
@@ -213,6 +216,7 @@ class PageController extends Controller
                 'label' => 'Header',
                 'elements' => [
                     ['type' => 'checkbox', 'label' => 'Tampilkan Seksi', 'id' => 'hero.visible'],
+                    ['type' => 'checkbox', 'label' => 'Gunakan Masker Gelap', 'id' => 'hero.mask'],
                     ['type' => 'image', 'label' => 'Gambar Latar', 'id' => 'hero.background'],
                     ['type' => 'text', 'label' => 'Judul', 'id' => 'hero.heading'],
                     ['type' => 'textarea', 'label' => 'Deskripsi Singkat', 'id' => 'hero.text'],
@@ -357,6 +361,7 @@ class PageController extends Controller
                     ['type' => 'checkbox', 'label' => 'Tampilkan Brand', 'id' => 'navigation.brand.visible'],
                     ['type' => 'text', 'label' => 'Nama Brand', 'id' => 'navigation.brand.text'],
                     ['type' => 'image', 'label' => 'Logo Brand', 'id' => 'navigation.brand.logo'],
+                    ['type' => 'text', 'label' => 'Kelas Ikon Brand', 'id' => 'navigation.brand.icon'],
                     ['type' => 'checkbox', 'label' => 'Tautan Home', 'id' => 'navigation.link.home'],
                     ['type' => 'checkbox', 'label' => 'Tautan Tentang Kami', 'id' => 'navigation.link.about'],
                     ['type' => 'checkbox', 'label' => 'Tautan Produk', 'id' => 'navigation.link.products'],

--- a/app/Support/LayoutSettings.php
+++ b/app/Support/LayoutSettings.php
@@ -33,6 +33,12 @@ class LayoutSettings
         $brandVisible = ($settings['navigation.brand.visible'] ?? '1') === '1';
         $brandLabel = $settings['navigation.brand.text'] ?? self::defaultBrandLabel($theme);
         $brandLogo = self::storageAsset($settings['navigation.brand.logo'] ?? null);
+        $brandIconSettingExists = array_key_exists('navigation.brand.icon', $settings);
+        $brandIconRaw = $settings['navigation.brand.icon'] ?? null;
+        $brandIcon = $brandIconRaw !== null ? trim((string) $brandIconRaw) : '';
+        if ($brandIcon === '') {
+            $brandIcon = $brandIconSettingExists ? null : 'fa fa-utensils';
+        }
 
         $links = [
             [
@@ -66,6 +72,7 @@ class LayoutSettings
                 'visible' => $brandVisible,
                 'label' => $brandLabel,
                 'logo' => $brandLogo,
+                'icon' => $brandIcon,
                 'url' => url('/'),
             ],
             'links' => $links,

--- a/app/Support/ThemeMedia.php
+++ b/app/Support/ThemeMedia.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Str;
+
+class ThemeMedia
+{
+    public static function url(?string $value): ?string
+    {
+        if (! $value) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (Str::startsWith($trimmed, ['http://', 'https://', '//'])) {
+            return $trimmed;
+        }
+
+        $normalized = ltrim($trimmed, '/');
+        $normalized = preg_replace('/^storage\//', '', $normalized);
+
+        return asset('storage/' . $normalized);
+    }
+}

--- a/themes/theme-restoran/views/components/nav-menu.blade.php
+++ b/themes/theme-restoran/views/components/nav-menu.blade.php
@@ -5,13 +5,16 @@
     $showCart = $showCart ?? true;
     $showLogin = $showLogin ?? false;
     $showIcons = $showCart || $showLogin;
+    $brandIcon = $brand['icon'] ?? null;
 @endphp
 <nav id="navigation" class="navbar navbar-expand-lg navbar-dark bg-dark px-4 px-lg-5 py-3 py-lg-0">
     @if ($brand['visible'])
         <a href="{{ $brand['url'] ?? url('/') }}" class="navbar-brand p-0 d-flex align-items-center gap-2">
-            <span class="text-primary d-inline-flex align-items-center justify-content-center" style="font-size: 1.5rem;">
-                <i class="fa fa-utensils"></i>
-            </span>
+            @if (!empty($brandIcon))
+                <span class="text-primary d-inline-flex align-items-center justify-content-center" style="font-size: 1.5rem;">
+                    <i class="{{ $brandIcon }}"></i>
+                </span>
+            @endif
             @if (!empty($brand['logo']))
                 <img src="{{ $brand['logo'] }}" alt="{{ $brand['label'] }}" class="img-fluid" style="max-height: 46px; width: auto;">
             @else

--- a/themes/theme-restoran/views/home.blade.php
+++ b/themes/theme-restoran/views/home.blade.php
@@ -32,6 +32,7 @@
     use App\Models\Product;
     use App\Support\Cart;
     use App\Support\LayoutSettings;
+    use App\Support\ThemeMedia;
     $themeName = $theme ?? 'theme-restoran';
     $settings = PageSetting::forPage('home');
     $products = Product::where('is_featured', true)->latest()->take(5)->get();
@@ -41,6 +42,17 @@
     $cartSummary = Cart::summary();
     $navigation = LayoutSettings::navigation($themeName);
     $footerConfig = LayoutSettings::footer($themeName);
+    $heroMaskEnabled = ($settings['hero.mask'] ?? '1') === '1';
+    $heroClasses = 'container-xxl py-5 hero-header mb-5' . ($heroMaskEnabled ? ' bg-dark' : '');
+    if (! $heroMaskEnabled) {
+        $heroClasses .= ' hero-no-mask';
+    }
+    $heroStyle = '';
+    if (! $heroMaskEnabled) {
+        $heroStyle = 'background-image: none;';
+    }
+    $heroImage = ThemeMedia::url($settings['hero.image'] ?? null);
+    $heroSpinImage = ThemeMedia::url($settings['hero.spin_image'] ?? null);
 @endphp
 <div class="container-xxl position-relative p-0">
     {!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
@@ -51,7 +63,7 @@
         'cart' => $cartSummary,
     ])->render() !!}
     @if(($settings['hero.visible'] ?? '1') == '1')
-    <div id="hero" class="container-xxl py-5 bg-dark hero-header mb-5">
+    <div id="hero" class="{{ $heroClasses }}" style="{{ $heroStyle }}">
         <div class="container my-5 py-5">
             <div class="row align-items-center g-5">
                 <div class="col-lg-6 text-center text-lg-start">
@@ -63,10 +75,10 @@
                     <a href="{{ $settings['hero.button_link'] ?? '#' }}" class="btn btn-primary py-sm-3 px-sm-5 me-3 animated slideInLeft">{{ $settings['hero.button_label'] ?? 'Book A Table' }}</a>
                 </div>
                 <div class="col-lg-6 text-center text-lg-end overflow-hidden position-relative">
-                    @if(!empty($settings['hero.spin_image']))
-                    <img class="img-fluid position-absolute top-0 start-0 spin" style="width:200px;" src="{{ asset('storage/'.$settings['hero.spin_image']) }}" alt="">
+                    @if($heroSpinImage)
+                    <img class="img-fluid position-absolute top-0 start-0 spin" style="width:200px;" src="{{ $heroSpinImage }}" alt="">
                     @endif
-                    <img class="img-fluid main" src="{{ !empty($settings['hero.image']) ? asset('storage/'.$settings['hero.image']) : asset('storage/themes/theme-restoran/img/hero.png') }}" alt="">
+                    <img class="img-fluid main" src="{{ $heroImage ?: asset('storage/themes/theme-restoran/img/hero.png') }}" alt="">
                     @if(!empty($settings['hero.spin_text']))
                     <span class="text-white position-absolute top-50 start-50 translate-middle spin-text">{{ $settings['hero.spin_text'] }}</span>
                     @endif

--- a/themes/theme-restoran/views/product-detail.blade.php
+++ b/themes/theme-restoran/views/product-detail.blade.php
@@ -34,12 +34,29 @@
     use App\Models\Product;
     use App\Support\Cart;
     use App\Support\LayoutSettings;
+    use App\Support\ThemeMedia;
 
     $themeName = $theme ?? 'theme-restoran';
     $settings = PageSetting::forPage('product-detail');
     $cartSummary = Cart::summary();
     $navigation = LayoutSettings::navigation($themeName);
     $footerConfig = LayoutSettings::footer($themeName);
+    $heroMaskEnabled = ($settings['hero.mask'] ?? '1') === '1';
+    $heroBackground = ThemeMedia::url($settings['hero.image'] ?? null);
+    $heroClasses = 'container-xxl py-5 hero-header mb-5' . ($heroMaskEnabled ? ' bg-dark' : '');
+    if (! $heroMaskEnabled) {
+        $heroClasses .= ' hero-no-mask';
+    }
+    $heroStyle = '';
+    if ($heroBackground) {
+        if ($heroMaskEnabled) {
+            $heroStyle = "background-image: linear-gradient(rgba(15, 23, 43, .9), rgba(15, 23, 43, .9)), url('{$heroBackground}'); background-size: cover; background-position: center;";
+        } else {
+            $heroStyle = "background-image: url('{$heroBackground}'); background-size: cover; background-position: center;";
+        }
+    } elseif (! $heroMaskEnabled) {
+        $heroStyle = 'background-image: none;';
+    }
 
     $images = $product->images ?? collect();
     $imageSources = $images->pluck('path')->filter()->map(fn($path) => asset('storage/'.$path))->values();
@@ -72,7 +89,7 @@
         'cart' => $cartSummary,
     ])->render() !!}
     @if(($settings['hero.visible'] ?? '1') == '1')
-    <div class="container-xxl py-5 bg-dark hero-header mb-5" @if(!empty($settings['hero.image'])) style="background-image:url('{{ asset('storage/'.$settings['hero.image']) }}'); background-size:cover; background-position:center;" @endif>
+    <div class="{{ $heroClasses }}" style="{{ $heroStyle }}">
         <div class="container text-center my-5 pt-5 pb-4">
             <h1 class="display-3 text-white mb-3">{{ $settings['hero.title'] ?? $product->name }}</h1>
             <nav aria-label="breadcrumb">

--- a/themes/theme-restoran/views/product.blade.php
+++ b/themes/theme-restoran/views/product.blade.php
@@ -23,6 +23,7 @@
     use App\Models\Category;
     use App\Support\Cart;
     use App\Support\LayoutSettings;
+    use App\Support\ThemeMedia;
     $themeName = $theme ?? 'theme-restoran';
     $settings = PageSetting::forPage('product');
     $query = Product::query();
@@ -38,6 +39,22 @@
     $cartSummary = Cart::summary();
     $navigation = LayoutSettings::navigation($themeName);
     $footerConfig = LayoutSettings::footer($themeName);
+    $heroMaskEnabled = ($settings['hero.mask'] ?? '1') === '1';
+    $heroBackground = ThemeMedia::url($settings['hero.image'] ?? null);
+    $heroClasses = 'container-xxl py-5 hero-header mb-5' . ($heroMaskEnabled ? ' bg-dark' : '');
+    if (! $heroMaskEnabled) {
+        $heroClasses .= ' hero-no-mask';
+    }
+    $heroStyle = '';
+    if ($heroBackground) {
+        if ($heroMaskEnabled) {
+            $heroStyle = "background-image: linear-gradient(rgba(15, 23, 43, .9), rgba(15, 23, 43, .9)), url('{$heroBackground}'); background-size: cover; background-position: center;";
+        } else {
+            $heroStyle = "background-image: url('{$heroBackground}'); background-size: cover; background-position: center;";
+        }
+    } elseif (! $heroMaskEnabled) {
+        $heroStyle = 'background-image: none;';
+    }
 @endphp
 <div class="container-xxl position-relative p-0">
     {!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
@@ -47,7 +64,7 @@
         'showLogin' => $navigation['show_login'],
         'cart' => $cartSummary,
     ])->render() !!}
-    <div class="container-xxl py-5 bg-dark hero-header mb-5">
+    <div class="{{ $heroClasses }}" style="{{ $heroStyle }}">
         <div class="container text-center my-5 pt-5 pb-4">
             <h1 class="display-3 text-white mb-3">{{ $settings['title'] ?? 'Produk Kami' }}</h1>
             <nav aria-label="breadcrumb">


### PR DESCRIPTION
## Summary
- add a reusable ThemeMedia helper and update Restoran hero sections to honor uploaded images and optional dark overlays
- align the Tentang Kami hero structure with other pages while using the new media resolver for intro and team imagery
- expose a configurable navigation brand icon so the default utensils can be replaced or removed

## Testing
- composer dump-autoload *(fails: Illuminate\\Foundation\\Application not found in bootstrap/app.php)*

------
https://chatgpt.com/codex/tasks/task_e_68da782a599c83298bf9c8b4612bc91f