### PR TITLE
Refine admin user navigation into team and customer views

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -18,6 +18,14 @@ class UserController extends Controller
 
         $query = User::query();
 
+        $view = $request->input('view');
+
+        if ($view === 'team') {
+            $query->whereIn('role', array_keys($managedRoles));
+        } elseif ($view === 'customers') {
+            $query->where('role', User::ROLE_BASIC);
+        }
+
         if ($search = trim((string) $request->input('search'))) {
             $query->where(function ($builder) use ($search) {
                 $builder->where('name', 'like', "%{$search}%")
@@ -34,6 +42,7 @@ class UserController extends Controller
         return view('admin.users.index', [
             'users' => $users,
             'managedRoles' => $managedRoles,
+            'currentView' => $view,
         ]);
     }
 
@@ -62,7 +71,9 @@ class UserController extends Controller
             'role' => $data['role'],
         ]);
 
-        return redirect()->route('admin.users.index')->with('success', 'Pengguna berhasil dibuat.');
+        return redirect()
+            ->route('admin.users.index', ['view' => 'team'])
+            ->with('success', 'Pengguna berhasil dibuat.');
     }
 
     public function edit(User $user): View
@@ -104,7 +115,9 @@ class UserController extends Controller
 
         $user->save();
 
-        return redirect()->route('admin.users.index')->with('success', 'Pengguna berhasil diperbarui.');
+        return redirect()
+            ->route('admin.users.index', ['view' => 'team'])
+            ->with('success', 'Pengguna berhasil diperbarui.');
     }
 
     public function destroy(User $user): RedirectResponse
@@ -114,12 +127,16 @@ class UserController extends Controller
         }
 
         if (auth()->id() === $user->getKey()) {
-            return redirect()->route('admin.users.index')->with('error', 'Anda tidak dapat menghapus akun sendiri.');
+            return redirect()
+                ->route('admin.users.index', ['view' => 'team'])
+                ->with('error', 'Anda tidak dapat menghapus akun sendiri.');
         }
 
         $user->delete();
 
-        return redirect()->route('admin.users.index')->with('success', 'Pengguna berhasil dihapus.');
+        return redirect()
+            ->route('admin.users.index', ['view' => 'team'])
+            ->with('success', 'Pengguna berhasil dihapus.');
     }
 
     /**

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,14 +1,25 @@
 @extends('layout.admin')
 
 @section('content')
+@php
+  $isCustomerView = $currentView === 'customers';
+  $pageTitle = $isCustomerView ? 'Konsumen' : 'Tim Saya';
+  $pageDescription = $isCustomerView
+    ? 'Lihat daftar pelanggan dengan peran Basic.'
+    : 'Kelola peran administrator, product manager, dan order manager.';
+  $formAction = route('admin.users.index', array_filter(['view' => $currentView]));
+@endphp
+
 <div class="main-panel">
   <div class="content-wrapper">
     <div class="page-header d-flex align-items-center justify-content-between">
       <div>
-        <h3 class="page-title mb-1">Manajemen Pengguna</h3>
-        <p class="text-muted mb-0">Kelola peran administrator, product manager, dan order manager.</p>
+        <h3 class="page-title mb-1">{{ $pageTitle }}</h3>
+        <p class="text-muted mb-0">{{ $pageDescription }}</p>
       </div>
-      <a href="{{ route('admin.users.create') }}" class="btn btn-primary">Tambah Pengguna</a>
+      @unless($isCustomerView)
+        <a href="{{ route('admin.users.create') }}" class="btn btn-primary">Tambah Pengguna</a>
+      @endunless
     </div>
 
     @if(session('success'))
@@ -21,7 +32,10 @@
 
     <div class="card">
       <div class="card-body">
-        <form method="GET" action="{{ route('admin.users.index') }}" class="mb-3">
+        <form method="GET" action="{{ $formAction }}" class="mb-3">
+          @if($currentView)
+            <input type="hidden" name="view" value="{{ $currentView }}">
+          @endif
           <div class="row g-2 align-items-end">
             <div class="col-md-5">
               <label for="search" class="form-label">Pencarian</label>
@@ -32,7 +46,9 @@
               <select name="role" id="role" class="form-control">
                 <option value="">Semua Peran</option>
                 @php
-                  $roleOptions = array_merge($managedRoles, [\App\Models\User::ROLE_BASIC => 'Basic']);
+                  $roleOptions = $isCustomerView
+                    ? [\App\Models\User::ROLE_BASIC => 'Basic']
+                    : $managedRoles;
                 @endphp
                 @foreach($roleOptions as $roleValue => $label)
                   <option value="{{ $roleValue }}" {{ request('role') === $roleValue ? 'selected' : '' }}>{{ $label }}</option>
@@ -41,7 +57,7 @@
             </div>
             <div class="col-md-3 d-flex gap-2">
               <button class="btn btn-primary flex-grow-1">Filter</button>
-              <a href="{{ route('admin.users.index') }}" class="btn btn-outline-secondary">Reset</a>
+              <a href="{{ route('admin.users.index', array_filter(['view' => $currentView])) }}" class="btn btn-outline-secondary">Reset</a>
             </div>
           </div>
         </form>

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -28,6 +28,10 @@
             \App\Models\User::ROLE_ORDER_MANAGER => 'Order Manager',
             \App\Models\User::ROLE_BASIC => 'Basic',
         ];
+        $usersView = request()->input('view');
+        $isUsersRoute = request()->routeIs('admin.users.*');
+        $isCustomersView = $isUsersRoute && $usersView === 'customers';
+        $isTeamView = $isUsersRoute && ! $isCustomersView;
     @endphp
     <div class="container-scroller">
       <nav class="sidebar sidebar-offcanvas" id="sidebar" style="overflow-y: auto;">
@@ -89,10 +93,21 @@
           @endif
           @if($currentUser?->isAdministrator())
           <li class="nav-item">
-            <a class="nav-link" href="{{ route('admin.users.index') }}">
+            <a class="nav-link" data-toggle="collapse" href="#users-menu" aria-expanded="{{ $isUsersRoute ? 'true' : 'false' }}" aria-controls="users-menu">
               <i class="mdi mdi-account-multiple menu-icon"></i>
               <span class="menu-title">Pengguna</span>
+              <i class="menu-arrow"></i>
             </a>
+            <div class="collapse {{ $isUsersRoute ? 'show' : '' }}" id="users-menu">
+              <ul class="nav flex-column sub-menu">
+                <li class="nav-item">
+                  <a class="nav-link {{ $isTeamView ? 'active' : '' }}" href="{{ route('admin.users.index', ['view' => 'team']) }}">Tim Saya</a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link {{ $isCustomersView ? 'active' : '' }}" href="{{ route('admin.users.index', ['view' => 'customers']) }}">Konsumen</a>
+                </li>
+              </ul>
+            </div>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="{{url('/admin/themes')}}">


### PR DESCRIPTION
## Summary
- add submenu items under the admin "Pengguna" menu for "Tim Saya" and "Konsumen"
- scope the admin users index to show either team members or customers based on the selected submenu
- persist the selected view when filtering or redirecting after user management actions

## Testing
- php artisan test *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da7dda021883298f12a2ab80101177