### PR TITLE
Add configurable article listing and detail pages for all themes

### DIFF
--- a/resources/views/admin/pages/article-detail.blade.php
+++ b/resources/views/admin/pages/article-detail.blade.php
@@ -1,0 +1,156 @@
+@extends('layout.admin')
+
+@php
+    $articles = collect($articles ?? []);
+@endphp
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="row">
+      <div class="col-md-4" id="elements" style="max-height:100vh; overflow-y:auto;">
+        @foreach ($sections as $key => $section)
+        <div class="card mb-3" data-section="{{ $key }}">
+          <div class="card-header">{{ $section['label'] }}</div>
+          <div class="card-body">
+            @foreach ($section['elements'] as $element)
+              <div class="form-group">
+                @if ($element['type'] === 'checkbox')
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" data-key="{{ $element['id'] }}" {{ ($settings[$element['id']] ?? '1') == '1' ? 'checked' : '' }}>
+                    <label class="form-check-label">{{ $element['label'] }}</label>
+                  </div>
+                @elseif ($element['type'] === 'text')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="text" class="form-control" data-key="{{ $element['id'] }}" value="{{ $settings[$element['id']] ?? '' }}">
+                @elseif ($element['type'] === 'textarea')
+                  <label>{{ $element['label'] }}</label>
+                  <textarea class="form-control" data-key="{{ $element['id'] }}">{{ $settings[$element['id']] ?? '' }}</textarea>
+                @elseif ($element['type'] === 'image')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="file" class="form-control-file" data-key="{{ $element['id'] }}">
+                @else
+                  <p class="text-muted mb-0">{{ $element['label'] }}</p>
+                @endif
+              </div>
+            @endforeach
+          </div>
+        </div>
+        @endforeach
+      </div>
+      <div class="col-md-8 position-sticky" style="top:0;height:100vh">
+        @if($previewUrl)
+          <iframe id="page-preview" src="{{ $previewUrl }}" class="w-100 border h-100"></iframe>
+        @else
+          <div class="h-100 d-flex align-items-center justify-content-center">
+            <div class="alert alert-info mb-0">Tambahkan artikel pada halaman artikel untuk melihat pratinjau detail.</div>
+          </div>
+        @endif
+      </div>
+    </div>
+
+    <div class="row mt-4">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header">Daftar Artikel Tersedia</div>
+          <div class="card-body p-0">
+            @if($articles->isEmpty())
+              <p class="text-muted p-3 mb-0">Belum ada artikel yang dapat dipratinjau.</p>
+            @else
+              <div class="table-responsive">
+                <table class="table table-striped mb-0">
+                  <thead>
+                    <tr>
+                      <th>Judul</th>
+                      <th>Slug</th>
+                      <th>Pratinjau</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @foreach($articles as $item)
+                      <tr>
+                        <td>{{ $item['title'] ?? '-' }}</td>
+                        <td>{{ $item['slug'] ?? '-' }}</td>
+                        <td>
+                          @if(!empty($item['slug']))
+                            <a href="{{ route('articles.show', ['slug' => $item['slug']]) }}" target="_blank" rel="noopener">Lihat</a>
+                          @else
+                            <span class="text-muted">-</span>
+                          @endif
+                        </td>
+                      </tr>
+                    @endforeach
+                  </tbody>
+                </table>
+              </div>
+            @endif
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+const csrf = '{{ csrf_token() }}';
+
+document.querySelectorAll('#elements [data-key]').forEach(function(input){
+  input.addEventListener('change', function(){
+    const key = this.getAttribute('data-key');
+    const formData = new FormData();
+    formData.append('key', key);
+    if(this.type === 'checkbox'){
+      formData.append('value', this.checked ? 1 : 0);
+    }else if(this.type === 'file'){
+      if(this.files[0]){ formData.append('value', this.files[0]); }
+    }else{
+      formData.append('value', this.value);
+    }
+
+    fetch('{{ route('admin.pages.article-detail.update') }}', {
+      method: 'POST',
+      headers: {'X-CSRF-TOKEN': csrf},
+      body: formData
+    }).then(() => {
+      const frame = document.getElementById('page-preview');
+      if(frame){
+        frame.contentWindow.location.reload();
+      }
+    });
+  });
+
+  if(input.type === 'file'){
+    input.addEventListener('input', function(){
+      const event = new Event('change');
+      this.dispatchEvent(event);
+    });
+  }
+});
+
+document.querySelectorAll('#elements .card').forEach(function(card){
+  card.addEventListener('mouseenter', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    if(iframe && iframe.contentWindow){
+      const section = iframe.contentWindow.document.getElementById(target);
+      if(section){
+        section.style.outline = '2px dashed #ff9800';
+        section.scrollIntoView({behavior:'smooth'});
+      }
+    }
+  });
+  card.addEventListener('mouseleave', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    if(iframe && iframe.contentWindow){
+      const section = iframe.contentWindow.document.getElementById(target);
+      if(section){
+        section.style.outline = '';
+      }
+    }
+  });
+});
+</script>
+@endsection

--- a/resources/views/admin/pages/article.blade.php
+++ b/resources/views/admin/pages/article.blade.php
@@ -1,0 +1,216 @@
+@extends('layout.admin')
+
+@php
+    $articles = collect($articles ?? []);
+@endphp
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="row">
+      <div class="col-md-4" id="elements" style="max-height:100vh; overflow-y:auto;">
+        @foreach ($sections as $key => $section)
+        <div class="card mb-3" data-section="{{ $key }}">
+          <div class="card-header">{{ $section['label'] }}</div>
+          <div class="card-body">
+            @foreach ($section['elements'] as $element)
+              <div class="form-group">
+                @if ($element['type'] === 'checkbox')
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" data-key="{{ $element['id'] }}" {{ ($settings[$element['id']] ?? '1') == '1' ? 'checked' : '' }}>
+                    <label class="form-check-label">{{ $element['label'] }}</label>
+                  </div>
+                @elseif ($element['type'] === 'text')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="text" class="form-control" data-key="{{ $element['id'] }}" value="{{ $settings[$element['id']] ?? '' }}">
+                @elseif ($element['type'] === 'textarea')
+                  <label>{{ $element['label'] }}</label>
+                  <textarea class="form-control" data-key="{{ $element['id'] }}">{{ $settings[$element['id']] ?? '' }}</textarea>
+                @elseif ($element['type'] === 'image')
+                  <label>{{ $element['label'] }}</label>
+                  <input type="file" class="form-control-file" data-key="{{ $element['id'] }}">
+                @elseif ($element['type'] === 'repeatable')
+                  @php
+                    $items = json_decode($settings[$element['id']] ?? '[]', true);
+                    $fields = $element['fields'] ?? [];
+                  @endphp
+                  <div data-repeatable="{{ $element['id'] }}" data-fields='@json($fields)'>
+                    <div class="repeatable-items"></div>
+                    <button type="button" class="btn btn-sm btn-secondary add-item">Add Item</button>
+                    <textarea class="d-none" data-key="{{ $element['id'] }}">{{ json_encode($items) }}</textarea>
+                  </div>
+                @else
+                  <p class="text-muted mb-0">{{ $element['label'] }}</p>
+                @endif
+              </div>
+            @endforeach
+          </div>
+        </div>
+        @endforeach
+      </div>
+      <div class="col-md-8 position-sticky" style="top:0;height:100vh">
+        @if($previewUrl)
+          <iframe id="page-preview" src="{{ $previewUrl }}" class="w-100 border h-100"></iframe>
+        @else
+          <div class="alert alert-info">Tambahkan minimal satu artikel untuk melihat pratinjau.</div>
+        @endif
+      </div>
+    </div>
+
+    <div class="row mt-4">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header">Ringkasan Artikel</div>
+          <div class="card-body p-0">
+            @if($articles->isEmpty())
+              <p class="text-muted p-3 mb-0">Belum ada artikel yang ditambahkan.</p>
+            @else
+              <div class="table-responsive">
+                <table class="table table-striped mb-0">
+                  <thead>
+                    <tr>
+                      <th>Judul</th>
+                      <th>Slug</th>
+                      <th>Penulis</th>
+                      <th>Tanggal</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @foreach($articles as $item)
+                      <tr>
+                        <td>{{ $item['title'] ?? '-' }}</td>
+                        <td>{{ $item['slug'] ?? '-' }}</td>
+                        <td>{{ $item['author'] ?? '-' }}</td>
+                        <td>{{ $item['date'] ?? '-' }}</td>
+                      </tr>
+                    @endforeach
+                  </tbody>
+                </table>
+              </div>
+            @endif
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+const csrf = '{{ csrf_token() }}';
+
+function updateSetting(input){
+  const key = input.getAttribute('data-key');
+  const formData = new FormData();
+  formData.append('key', key);
+  if(input.type === 'checkbox'){
+    formData.append('value', input.checked ? 1 : 0);
+  }else if(input.type === 'file'){
+    if(input.files[0]){ formData.append('value', input.files[0]); }
+  }else{
+    formData.append('value', input.value);
+  }
+
+  fetch('{{ route('admin.pages.article.update') }}', {
+    method: 'POST',
+    headers: {'X-CSRF-TOKEN': csrf},
+    body: formData
+  }).then(() => {
+    const frame = document.getElementById('page-preview');
+    if(frame){
+      frame.contentWindow.location.reload();
+    }
+  });
+}
+
+document.querySelectorAll('#elements [data-key]').forEach(function(input){
+  input.addEventListener('change', function(){
+    updateSetting(this);
+  });
+  if(input.type === 'file'){
+    input.addEventListener('input', function(){
+      updateSetting(this);
+    });
+  }
+});
+
+document.querySelectorAll('[data-repeatable]').forEach(function(wrapper){
+  const itemsContainer = wrapper.querySelector('.repeatable-items');
+  const hidden = wrapper.querySelector('[data-key]');
+  const fields = JSON.parse(wrapper.getAttribute('data-fields') || '[]');
+
+  function buildItem(data = {}){
+    const div = document.createElement('div');
+    div.className = 'repeatable-item mb-2 border rounded p-2';
+    let html = '';
+    fields.forEach(function(field){
+      if((field.type || 'text') === 'textarea'){
+        html += `<textarea class="form-control mb-1" data-field="${field.name}" placeholder="${field.placeholder}">${data[field.name] || ''}</textarea>`;
+      }else{
+        html += `<input type="text" class="form-control mb-1" data-field="${field.name}" placeholder="${field.placeholder}" value="${data[field.name] || ''}">`;
+      }
+    });
+    html += '<button type="button" class="btn btn-sm btn-danger remove-item">Remove</button>';
+    div.innerHTML = html;
+    return div;
+  }
+
+  function sync(){
+    const data = [];
+    itemsContainer.querySelectorAll('.repeatable-item').forEach(function(item){
+      const obj = {};
+      item.querySelectorAll('[data-field]').forEach(function(input){
+        obj[input.getAttribute('data-field')] = input.value;
+      });
+      data.push(obj);
+    });
+    hidden.value = JSON.stringify(data);
+    hidden.dispatchEvent(new Event('change'));
+  }
+
+  wrapper.querySelector('.add-item').addEventListener('click', function(){
+    itemsContainer.appendChild(buildItem());
+  });
+
+  itemsContainer.addEventListener('input', sync);
+  itemsContainer.addEventListener('click', function(e){
+    if(e.target.classList.contains('remove-item')){
+      e.target.closest('.repeatable-item').remove();
+      sync();
+    }
+  });
+
+  try {
+    JSON.parse(hidden.value || '[]').forEach(function(item){
+      itemsContainer.appendChild(buildItem(item));
+    });
+  } catch(e) {}
+  sync();
+});
+
+document.querySelectorAll('#elements .card').forEach(function(card){
+  card.addEventListener('mouseenter', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    if(iframe && iframe.contentWindow){
+      const section = iframe.contentWindow.document.getElementById(target);
+      if(section){
+        section.style.outline = '2px dashed #ff9800';
+        section.scrollIntoView({behavior:'smooth'});
+      }
+    }
+  });
+  card.addEventListener('mouseleave', function(){
+    const target = card.getAttribute('data-section');
+    const iframe = document.getElementById('page-preview');
+    if(iframe && iframe.contentWindow){
+      const section = iframe.contentWindow.document.getElementById(target);
+      if(section){
+        section.style.outline = '';
+      }
+    }
+  });
+});
+</script>
+@endsection

--- a/themes/theme-herbalgreen/views/article-detail.blade.php
+++ b/themes/theme-herbalgreen/views/article-detail.blade.php
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ $pageTitle ?? 'Artikel' }}</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+    use Illuminate\Support\Carbon;
+
+    $themeName = $theme ?? 'theme-herbalgreen';
+    $detailSettings = PageSetting::forPage('article-detail');
+    $listSettings = PageSetting::forPage('article');
+
+    $rawArticles = collect($articles ?? json_decode($listSettings['articles.items'] ?? '[]', true));
+    $prepared = $rawArticles->filter(fn ($item) => !empty($item['slug']))->map(function ($item) {
+        $date = null;
+        if (!empty($item['date'])) {
+            try {
+                $date = Carbon::parse($item['date']);
+            } catch (\Exception $e) {
+                $date = null;
+            }
+        }
+        $item['date_object'] = $date;
+        $item['date_formatted'] = $date ? $date->locale(app()->getLocale())->isoFormat('D MMMM Y') : null;
+        return $item;
+    });
+
+    $currentSlug = $article['slug'] ?? null;
+    $current = $prepared->firstWhere('slug', $currentSlug) ?? $article;
+    if (!is_array($current)) {
+        $current = (array) $current;
+    }
+
+    $dateObject = $current['date_object'] ?? null;
+    if (!$dateObject && !empty($current['date'])) {
+        try {
+            $dateObject = Carbon::parse($current['date']);
+        } catch (\Exception $e) {
+            $dateObject = null;
+        }
+    }
+
+    $dateFormatted = $dateObject ? $dateObject->locale(app()->getLocale())->isoFormat('D MMMM Y') : null;
+
+    $pageTitle = $current['title'] ?? 'Artikel';
+
+    $recommended = $prepared->filter(fn ($item) => $item['slug'] !== $currentSlug)->sortByDesc(function ($item) {
+        return optional($item['date_object'])->timestamp ?? 0;
+    })->take(3);
+
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
+    $cartSummary = Cart::summary();
+
+    function hg_article_image($path) {
+        if (empty($path)) {
+            return null;
+        }
+        if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://')) {
+            return $path;
+        }
+        return asset('storage/' . ltrim($path, '/'));
+    }
+@endphp
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
+
+@if(($detailSettings['hero.visible'] ?? '1') == '1')
+<section id="hero" class="page-hero" style="background-image:url('{{ !empty($detailSettings['hero.image']) ? asset('storage/'.$detailSettings['hero.image']) : 'https://images.unsplash.com/photo-1487611459768-bd414656ea10?auto=format&fit=crop&w=1600&q=80' }}')">
+    <div class="overlay{{ ($detailSettings['hero.mask'] ?? '0') == '1' ? ' overlay-dark' : '' }}"></div>
+    <div class="page-hero__content">
+        <span class="tagline">{{ $detailSettings['hero.title'] ?? 'Artikel' }}</span>
+        <h1>{{ $current['title'] ?? 'Artikel' }}</h1>
+    </div>
+</section>
+@endif
+
+<section id="content" class="article-detail">
+    <article class="article-detail__main">
+        @php $image = hg_article_image($current['image'] ?? null); @endphp
+        @if($image)
+            <div class="article-detail__media" style="background-image:url('{{ $image }}')"></div>
+        @endif
+        <div class="article-detail__body">
+            <div class="article-detail__meta">
+                @if(($detailSettings['meta.show_date'] ?? '1') == '1' && $dateFormatted)
+                    <span>{{ $dateFormatted }}</span>
+                @endif
+                @if(($detailSettings['meta.show_author'] ?? '1') == '1' && !empty($current['author']))
+                    <span>• {{ $current['author'] }}</span>
+                @endif
+            </div>
+            <h1>{{ $current['title'] ?? 'Artikel' }}</h1>
+            <div class="article-detail__content">
+                {!! $current['content'] ?? '<p>Konten artikel belum tersedia.</p>' !!}
+            </div>
+        </div>
+        <div id="comments" class="article-detail__comments">
+            @if(($detailSettings['comments.visible'] ?? '1') == '1')
+                <h2>{{ $detailSettings['comments.heading'] ?? 'Komentar' }}</h2>
+                <p class="text-muted">Fitur komentar akan tersedia segera.</p>
+            @else
+                <div class="article-detail__notice">{{ $detailSettings['comments.disabled_text'] ?? 'Komentar dimatikan.' }}</div>
+            @endif
+        </div>
+    </article>
+    <aside id="recommendations" class="article-detail__sidebar">
+        @if(($detailSettings['recommendations.visible'] ?? '1') == '1' && $recommended->isNotEmpty())
+            <div class="sidebar-card">
+                <h3>{{ $detailSettings['recommendations.heading'] ?? 'Artikel Lainnya' }}</h3>
+                <ul class="sidebar-list">
+                    @foreach($recommended as $item)
+                        <li>
+                            <a href="{{ route('articles.show', ['slug' => $item['slug']]) }}">
+                                <span class="title">{{ $item['title'] ?? 'Artikel' }}</span>
+                                <span class="date">{{ $item['date_formatted'] ?? '' }}</span>
+                            </a>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+    </aside>
+</section>
+
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+@once
+<style>
+    .page-hero {
+        position: relative;
+        background-size: cover;
+        background-position: center;
+        min-height: 40vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        color: #fff;
+    }
+    .page-hero .overlay {
+        position: absolute;
+        inset: 0;
+        background: rgba(255,255,255,0.45);
+    }
+    .page-hero .overlay.overlay-dark {
+        background: rgba(0,0,0,0.5);
+    }
+    .page-hero__content {
+        position: relative;
+        max-width: 640px;
+    }
+    .page-hero__content .tagline {
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        font-weight: 600;
+        color: #fff;
+    }
+    .page-hero__content h1 {
+        margin: 0.5rem 0 0;
+        color: #fff;
+    }
+    .article-detail {
+        display: grid;
+        grid-template-columns: minmax(0, 3fr) minmax(260px, 1fr);
+        gap: 2.5rem;
+        padding: 4rem 2rem;
+    }
+    @media (max-width: 992px) {
+        .article-detail {
+            grid-template-columns: 1fr;
+        }
+    }
+    .article-detail__main {
+        background: #fff;
+        border-radius: 16px;
+        box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+    }
+    .article-detail__media {
+        padding-top: 56%;
+        background-size: cover;
+        background-position: center;
+    }
+    .article-detail__body {
+        padding: 2.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+    .article-detail__meta {
+        font-size: 0.9rem;
+        color: rgba(27, 94, 32, 0.7);
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+    }
+    .article-detail__content p {
+        line-height: 1.7;
+        margin-bottom: 1.5rem;
+    }
+    .article-detail__comments {
+        padding: 2.5rem;
+        border-top: 1px solid rgba(46, 125, 50, 0.1);
+    }
+    .article-detail__comments h2 {
+        margin-top: 0;
+    }
+    .article-detail__comments .text-muted {
+        color: rgba(27, 94, 32, 0.6);
+    }
+    .article-detail__notice {
+        background: rgba(46, 125, 50, 0.1);
+        padding: 1rem 1.25rem;
+        border-radius: 8px;
+        color: rgba(27, 94, 32, 0.8);
+    }
+    .article-detail__sidebar {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+    .sidebar-card {
+        background: #fff;
+        border-radius: 16px;
+        box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+        padding: 1.75rem;
+    }
+    .sidebar-card h3 {
+        margin-top: 0;
+    }
+    .sidebar-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+    .sidebar-list li a {
+        display: flex;
+        flex-direction: column;
+        text-decoration: none;
+        color: var(--color-text);
+        gap: 0.25rem;
+    }
+    .sidebar-list li a:hover .title {
+        color: var(--color-primary);
+    }
+    .sidebar-list .date {
+        font-size: 0.85rem;
+        color: rgba(27, 94, 32, 0.6);
+    }
+</style>
+@endonce
+</body>
+</html>

--- a/themes/theme-herbalgreen/views/article.blade.php
+++ b/themes/theme-herbalgreen/views/article.blade.php
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ $pageTitle ?? 'Artikel' }}</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+    use Illuminate\Support\Carbon;
+
+    $themeName = $theme ?? 'theme-herbalgreen';
+    $settings = PageSetting::forPage('article');
+    $rawArticles = collect(json_decode($settings['articles.items'] ?? '[]', true));
+
+    $allArticles = $rawArticles->filter(fn ($item) => !empty($item['slug']))->map(function ($item) {
+        $date = null;
+        if (!empty($item['date'])) {
+            try {
+                $date = Carbon::parse($item['date']);
+            } catch (\Exception $e) {
+                $date = null;
+            }
+        }
+        $item['date_object'] = $date;
+        $item['date_formatted'] = $date ? $date->locale(app()->getLocale())->isoFormat('D MMMM Y') : null;
+        $item['year'] = $date ? (int) $date->format('Y') : null;
+        $item['month'] = $date ? $date->format('m') : null;
+        $item['month_name'] = $date ? $date->locale(app()->getLocale())->isoFormat('MMMM') : null;
+        return $item;
+    });
+
+    $timeline = $allArticles->filter(fn ($item) => $item['year'] && $item['month'])->groupBy('year')->sortKeysDesc()->map(function ($group) {
+        return $group->groupBy('month')->sortKeysDesc()->map(function ($monthGroup) {
+            $first = $monthGroup->first();
+            return [
+                'name' => $first['month_name'] ?? '',
+                'articles' => $monthGroup->sortByDesc(function ($article) {
+                    return optional($article['date_object'])->timestamp ?? 0;
+                })->values(),
+            ];
+        });
+    });
+
+    $articles = $allArticles;
+
+    if ($search = trim(request('search', ''))) {
+        $lower = mb_strtolower($search);
+        $articles = $articles->filter(function ($item) use ($lower) {
+            $haystack = mb_strtolower(($item['title'] ?? '') . ' ' . ($item['excerpt'] ?? '') . ' ' . ($item['content'] ?? ''));
+            return str_contains($haystack, $lower);
+        });
+    }
+
+    if ($yearFilter = request('year')) {
+        $articles = $articles->filter(fn ($item) => (string) ($item['year'] ?? '') === (string) $yearFilter);
+    }
+
+    if ($monthFilter = request('month')) {
+        $monthFilter = str_pad($monthFilter, 2, '0', STR_PAD_LEFT);
+        $articles = $articles->filter(fn ($item) => ($item['month'] ?? '') === $monthFilter);
+    }
+
+    $articles = $articles->sortByDesc(function ($article) {
+        return optional($article['date_object'])->timestamp ?? 0;
+    })->values();
+
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
+    $cartSummary = Cart::summary();
+
+    $pageTitle = $settings['hero.heading'] ?? 'Artikel';
+    $buttonLabel = $settings['list.button_label'] ?? 'Baca Selengkapnya';
+    $emptyText = $settings['list.empty_text'] ?? 'Belum ada artikel.';
+    $searchPlaceholder = $settings['search.placeholder'] ?? 'Cari artikel...';
+
+    function hg_article_image($path) {
+        if (empty($path)) {
+            return null;
+        }
+        if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://')) {
+            return $path;
+        }
+        return asset('storage/' . ltrim($path, '/'));
+    }
+@endphp
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
+
+@if(($settings['hero.visible'] ?? '1') == '1')
+<section id="hero" class="page-hero" style="background-image:url('{{ !empty($settings['hero.image']) ? asset('storage/'.$settings['hero.image']) : 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80' }}')">
+    <div class="overlay{{ ($settings['hero.mask'] ?? '0') == '1' ? ' overlay-dark' : '' }}"></div>
+    <div class="page-hero__content">
+        <span class="tagline">{{ $settings['hero.description'] ?? 'Kabar dan cerita terbaru' }}</span>
+        <h1>{{ $settings['hero.heading'] ?? 'Artikel' }}</h1>
+    </div>
+</section>
+@endif
+
+<section id="list" class="article-layout">
+    <div class="article-layout__content">
+        @forelse($articles as $article)
+            <article class="article-card">
+                @php $image = hg_article_image($article['image'] ?? null); @endphp
+                @if($image)
+                    <div class="article-card__media" style="background-image:url('{{ $image }}')"></div>
+                @endif
+                <div class="article-card__body">
+                    <div class="article-card__meta">
+                        @if(!empty($article['date_formatted']))
+                            <span>{{ $article['date_formatted'] }}</span>
+                        @endif
+                        @if(!empty($article['author']))
+                            <span>• {{ $article['author'] }}</span>
+                        @endif
+                    </div>
+                    <h2>{{ $article['title'] ?? 'Artikel' }}</h2>
+                    @if(!empty($article['excerpt']))
+                        <p>{{ $article['excerpt'] }}</p>
+                    @endif
+                    <a href="{{ route('articles.show', ['slug' => $article['slug']]) }}" class="article-card__link">{{ $buttonLabel }}</a>
+                </div>
+            </article>
+        @empty
+            <div class="article-empty">{{ $emptyText }}</div>
+        @endforelse
+    </div>
+    <aside class="article-layout__sidebar">
+        <div id="search" class="sidebar-card">
+            <h3>Cari Artikel</h3>
+            <form method="GET" class="sidebar-search">
+                <input type="hidden" name="year" value="{{ request('year') }}">
+                <input type="hidden" name="month" value="{{ request('month') }}">
+                <input type="text" name="search" placeholder="{{ $searchPlaceholder }}" value="{{ request('search') }}">
+                <button type="submit">Cari</button>
+            </form>
+            @if(request()->filled('search') || request()->filled('year') || request()->filled('month'))
+                <a href="{{ route('articles.index') }}" class="sidebar-reset">Reset Filter</a>
+            @endif
+        </div>
+        @if(($settings['timeline.visible'] ?? '1') == '1')
+        <div id="timeline" class="sidebar-card">
+            <h3>{{ $settings['timeline.heading'] ?? 'Arsip' }}</h3>
+            @if($timeline->isEmpty())
+                <p class="text-muted">Belum ada arsip.</p>
+            @else
+                <div class="timeline">
+                    @foreach($timeline as $year => $months)
+                        <div class="timeline__year">
+                            <h4>{{ $year }}</h4>
+                            <ul>
+                                @foreach($months as $monthKey => $monthData)
+                                    <li>
+                                        <a href="{{ route('articles.index', ['year' => $year, 'month' => $monthKey]) }}">{{ $monthData['name'] ?? $monthKey }} ({{ $monthData['articles']->count() }})</a>
+                                        <ul>
+                                            @foreach($monthData['articles'] as $item)
+                                                <li><a href="{{ route('articles.show', ['slug' => $item['slug']]) }}">{{ $item['title'] ?? 'Artikel' }}</a></li>
+                                            @endforeach
+                                        </ul>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+        </div>
+        @endif
+    </aside>
+</section>
+
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+@once
+<style>
+    .page-hero {
+        position: relative;
+        background-size: cover;
+        background-position: center;
+        min-height: 45vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        color: #fff;
+    }
+    .page-hero .overlay {
+        position: absolute;
+        inset: 0;
+        background: rgba(255,255,255,0.45);
+    }
+    .page-hero .overlay.overlay-dark {
+        background: rgba(0,0,0,0.45);
+    }
+    .page-hero__content {
+        position: relative;
+        max-width: 600px;
+    }
+    .page-hero__content h1 {
+        font-size: 2.5rem;
+        margin: 0.5rem 0 0;
+        color: #fff;
+    }
+    .page-hero__content .tagline {
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        font-weight: 600;
+    }
+    .article-layout {
+        display: grid;
+        grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+        gap: 2.5rem;
+        padding: 4rem 2rem;
+    }
+    @media (max-width: 992px) {
+        .article-layout {
+            grid-template-columns: 1fr;
+        }
+    }
+    .article-layout__content {
+        display: grid;
+        gap: 2rem;
+    }
+    .article-card {
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+    }
+    .article-card__media {
+        padding-top: 56%;
+        background-size: cover;
+        background-position: center;
+    }
+    .article-card__body {
+        padding: 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+    .article-card__meta {
+        font-size: 0.9rem;
+        color: rgba(27, 94, 32, 0.7);
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+    .article-card h2 {
+        margin: 0;
+        font-size: 1.5rem;
+        color: var(--color-text);
+    }
+    .article-card__link {
+        align-self: flex-start;
+        text-decoration: none;
+        font-weight: 600;
+        color: var(--color-primary);
+    }
+    .article-card__link:hover {
+        color: var(--color-accent);
+    }
+    .article-empty {
+        background: #fff;
+        border-radius: 12px;
+        padding: 2rem;
+        text-align: center;
+        color: rgba(27, 94, 32, 0.7);
+    }
+    .article-layout__sidebar {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+    .sidebar-card {
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+        padding: 1.5rem;
+    }
+    .sidebar-card h3 {
+        margin-top: 0;
+    }
+    .sidebar-search {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+    .sidebar-search input {
+        padding: 0.75rem 1rem;
+        border: 1px solid rgba(46, 125, 50, 0.2);
+        border-radius: 8px;
+    }
+    .sidebar-search button {
+        padding: 0.75rem 1rem;
+        border: none;
+        border-radius: 8px;
+        background: var(--color-primary);
+        color: #fff;
+        cursor: pointer;
+    }
+    .sidebar-search button:hover {
+        background: var(--color-accent);
+    }
+    .sidebar-reset {
+        display: inline-block;
+        margin-top: 0.75rem;
+        font-size: 0.9rem;
+        color: var(--color-primary);
+        text-decoration: none;
+    }
+    .sidebar-reset:hover {
+        color: var(--color-accent);
+    }
+    .timeline ul {
+        list-style: none;
+        margin: 0;
+        padding-left: 1rem;
+    }
+    .timeline__year {
+        margin-bottom: 1.5rem;
+    }
+    .timeline__year h4 {
+        margin-bottom: 0.5rem;
+    }
+    .timeline__year > ul > li {
+        margin-bottom: 0.75rem;
+    }
+    .timeline__year a {
+        color: var(--color-text);
+        text-decoration: none;
+    }
+    .timeline__year a:hover {
+        color: var(--color-primary);
+    }
+    .timeline__year ul ul {
+        padding-left: 1rem;
+        margin-top: 0.5rem;
+    }
+</style>
+@endonce
+</body>
+</html>

--- a/themes/theme-restoran/views/article-detail.blade.php
+++ b/themes/theme-restoran/views/article-detail.blade.php
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ $pageTitle ?? 'Artikel' }}</title>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <link href="{{ asset('storage/themes/theme-restoran/img/favicon.ico') }}" rel="icon">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600&family=Nunito:wght@600;700;800&family=Pacifico&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.0/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/animate/animate.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/assets/owl.carousel.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/css/tempusdominus-bootstrap-4.min.css') }}" rel="stylesheet" />
+    <link href="{{ asset('storage/themes/theme-restoran/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/css/style.css') }}" rel="stylesheet">
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+    use App\Support\ThemeMedia;
+    use Illuminate\Support\Carbon;
+
+    $themeName = $theme ?? 'theme-restoran';
+    $detailSettings = PageSetting::forPage('article-detail');
+    $listSettings = PageSetting::forPage('article');
+
+    $rawArticles = collect($articles ?? json_decode($listSettings['articles.items'] ?? '[]', true));
+    $prepared = $rawArticles->filter(fn ($item) => !empty($item['slug']))->map(function ($item) {
+        $date = null;
+        if (!empty($item['date'])) {
+            try {
+                $date = Carbon::parse($item['date']);
+            } catch (\Exception $e) {
+                $date = null;
+            }
+        }
+        $item['date_object'] = $date;
+        $item['date_formatted'] = $date ? $date->locale(app()->getLocale())->isoFormat('D MMMM Y') : null;
+        return $item;
+    });
+
+    $currentSlug = $article['slug'] ?? null;
+    $current = $prepared->firstWhere('slug', $currentSlug) ?? $article;
+    if (!is_array($current)) {
+        $current = (array) $current;
+    }
+
+    $dateObject = $current['date_object'] ?? null;
+    if (!$dateObject && !empty($current['date'])) {
+        try {
+            $dateObject = Carbon::parse($current['date']);
+        } catch (\Exception $e) {
+            $dateObject = null;
+        }
+    }
+    $dateFormatted = $dateObject ? $dateObject->locale(app()->getLocale())->isoFormat('D MMMM Y') : null;
+
+    $pageTitle = $current['title'] ?? 'Artikel';
+
+    $recommended = $prepared->filter(fn ($item) => $item['slug'] !== $currentSlug)->sortByDesc(function ($item) {
+        return optional($item['date_object'])->timestamp ?? 0;
+    })->take(3);
+
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
+    $cartSummary = Cart::summary();
+
+    $heroMaskEnabled = ($detailSettings['hero.mask'] ?? '1') === '1';
+    $heroBackground = ThemeMedia::url($detailSettings['hero.image'] ?? null) ?? asset('storage/themes/theme-restoran/img/breadcrumb.jpg');
+    $heroClasses = 'container-xxl py-5 hero-header mb-5' . ($heroMaskEnabled ? ' bg-dark' : '');
+    if (! $heroMaskEnabled) {
+        $heroClasses .= ' hero-no-mask';
+    }
+    $heroStyle = "background-image: url('{$heroBackground}'); background-size: cover; background-position: center;";
+
+    function restoran_article_image($path) {
+        if (empty($path)) {
+            return null;
+        }
+        if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://')) {
+            return $path;
+        }
+        return asset('storage/' . ltrim($path, '/'));
+    }
+@endphp
+<div class="container-xxl position-relative p-0">
+    {!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+        'brand' => $navigation['brand'],
+        'links' => $navigation['links'],
+        'showCart' => $navigation['show_cart'],
+        'showLogin' => $navigation['show_login'],
+        'cart' => $cartSummary,
+    ])->render() !!}
+    @if(($detailSettings['hero.visible'] ?? '1') == '1')
+    <div id="hero" class="{{ $heroClasses }}" style="{{ $heroStyle }}">
+        <div class="container text-center my-5 pt-5 pb-4">
+            <h1 class="display-3 text-white mb-3">{{ $current['title'] ?? ($detailSettings['hero.title'] ?? 'Artikel') }}</h1>
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb justify-content-center text-uppercase">
+                    <li class="breadcrumb-item"><a href="{{ url('/') }}">Home</a></li>
+                    <li class="breadcrumb-item"><a href="{{ route('articles.index') }}">Artikel</a></li>
+                    <li class="breadcrumb-item text-white active" aria-current="page">{{ $detailSettings['hero.title'] ?? ($current['title'] ?? 'Detail') }}</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+    @endif
+</div>
+
+<div id="content" class="container py-5">
+    <div class="row g-5">
+        <div class="col-lg-8">
+            <article class="card border-0 shadow-sm">
+                @php $image = restoran_article_image($current['image'] ?? null); @endphp
+                @if($image)
+                    <img src="{{ $image }}" class="card-img-top" alt="{{ $current['title'] ?? 'Artikel' }}">
+                @endif
+                <div class="card-body p-4">
+                    <div class="d-flex align-items-center text-muted mb-3 small">
+                        @if(($detailSettings['meta.show_date'] ?? '1') == '1' && $dateFormatted)
+                            <span class="me-3"><i class="far fa-calendar-alt me-1"></i>{{ $dateFormatted }}</span>
+                        @endif
+                        @if(($detailSettings['meta.show_author'] ?? '1') == '1' && !empty($current['author']))
+                            <span><i class="far fa-user me-1"></i>{{ $current['author'] }}</span>
+                        @endif
+                    </div>
+                    <h1 class="mb-4 h3">{{ $current['title'] ?? 'Artikel' }}</h1>
+                    <div class="article-content">
+                        {!! $current['content'] ?? '<p>Konten artikel belum tersedia.</p>' !!}
+                    </div>
+                </div>
+            </article>
+            <section id="comments" class="card border-0 shadow-sm mt-4">
+                <div class="card-body">
+                    @if(($detailSettings['comments.visible'] ?? '1') == '1')
+                        <h4 class="mb-3">{{ $detailSettings['comments.heading'] ?? 'Komentar' }}</h4>
+                        <p class="text-muted mb-0">Fitur komentar akan segera tersedia.</p>
+                    @else
+                        <div class="alert alert-light border mb-0">{{ $detailSettings['comments.disabled_text'] ?? 'Komentar dinonaktifkan.' }}</div>
+                    @endif
+                </div>
+            </section>
+        </div>
+        <div id="recommendations" class="col-lg-4">
+            @if(($detailSettings['recommendations.visible'] ?? '1') == '1' && $recommended->isNotEmpty())
+            <div class="card border-0 shadow-sm">
+                <div class="card-body">
+                    <h4 class="card-title">{{ $detailSettings['recommendations.heading'] ?? 'Artikel Lainnya' }}</h4>
+                    <ul class="list-unstyled mb-0">
+                        @foreach($recommended as $item)
+                            <li class="mb-3">
+                                <a href="{{ route('articles.show', ['slug' => $item['slug']]) }}" class="text-decoration-none">
+                                    <span class="d-block fw-semibold">{{ $item['title'] ?? 'Artikel' }}</span>
+                                    <small class="text-muted">{{ $item['date_formatted'] ?? '' }}</small>
+                                </a>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            </div>
+            @endif
+        </div>
+    </div>
+</div>
+
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/wow/wow.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/easing/easing.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/waypoints/waypoints.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/counterup/counterup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment-timezone.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/tempusdominus-bootstrap-4.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/js/main.js') }}"></script>
+</body>
+</html>

--- a/themes/theme-restoran/views/article.blade.php
+++ b/themes/theme-restoran/views/article.blade.php
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ $pageTitle ?? 'Artikel' }}</title>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <link href="{{ asset('storage/themes/theme-restoran/img/favicon.ico') }}" rel="icon">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600&family=Nunito:wght@600;700;800&family=Pacifico&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.0/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/animate/animate.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/assets/owl.carousel.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/css/tempusdominus-bootstrap-4.min.css') }}" rel="stylesheet" />
+    <link href="{{ asset('storage/themes/theme-restoran/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ asset('storage/themes/theme-restoran/css/style.css') }}" rel="stylesheet">
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+    use App\Support\ThemeMedia;
+    use Illuminate\Support\Carbon;
+
+    $themeName = $theme ?? 'theme-restoran';
+    $settings = PageSetting::forPage('article');
+    $rawArticles = collect(json_decode($settings['articles.items'] ?? '[]', true));
+
+    $allArticles = $rawArticles->filter(fn ($item) => !empty($item['slug']))->map(function ($item) {
+        $date = null;
+        if (!empty($item['date'])) {
+            try {
+                $date = Carbon::parse($item['date']);
+            } catch (\Exception $e) {
+                $date = null;
+            }
+        }
+        $item['date_object'] = $date;
+        $item['date_formatted'] = $date ? $date->locale(app()->getLocale())->isoFormat('D MMMM Y') : null;
+        $item['year'] = $date ? (int) $date->format('Y') : null;
+        $item['month'] = $date ? $date->format('m') : null;
+        $item['month_name'] = $date ? $date->locale(app()->getLocale())->isoFormat('MMMM') : null;
+        return $item;
+    });
+
+    $timeline = $allArticles->filter(fn ($item) => $item['year'] && $item['month'])->groupBy('year')->sortKeysDesc()->map(function ($group) {
+        return $group->groupBy('month')->sortKeysDesc()->map(function ($monthGroup) {
+            $first = $monthGroup->first();
+            return [
+                'name' => $first['month_name'] ?? '',
+                'articles' => $monthGroup->sortByDesc(function ($article) {
+                    return optional($article['date_object'])->timestamp ?? 0;
+                })->values(),
+            ];
+        });
+    });
+
+    $articles = $allArticles;
+
+    if ($search = trim(request('search', ''))) {
+        $lower = mb_strtolower($search);
+        $articles = $articles->filter(function ($item) use ($lower) {
+            $haystack = mb_strtolower(($item['title'] ?? '') . ' ' . ($item['excerpt'] ?? '') . ' ' . ($item['content'] ?? ''));
+            return str_contains($haystack, $lower);
+        });
+    }
+
+    if ($yearFilter = request('year')) {
+        $articles = $articles->filter(fn ($item) => (string) ($item['year'] ?? '') === (string) $yearFilter);
+    }
+
+    if ($monthFilter = request('month')) {
+        $monthFilter = str_pad($monthFilter, 2, '0', STR_PAD_LEFT);
+        $articles = $articles->filter(fn ($item) => ($item['month'] ?? '') === $monthFilter);
+    }
+
+    $articles = $articles->sortByDesc(function ($article) {
+        return optional($article['date_object'])->timestamp ?? 0;
+    })->values();
+
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
+    $cartSummary = Cart::summary();
+
+    $pageTitle = $settings['hero.heading'] ?? 'Artikel';
+    $buttonLabel = $settings['list.button_label'] ?? 'Baca Selengkapnya';
+    $emptyText = $settings['list.empty_text'] ?? 'Belum ada artikel tersedia.';
+    $searchPlaceholder = $settings['search.placeholder'] ?? 'Cari artikel...';
+
+    $heroMaskEnabled = ($settings['hero.mask'] ?? '1') === '1';
+    $heroBackground = ThemeMedia::url($settings['hero.image'] ?? null) ?? asset('storage/themes/theme-restoran/img/breadcrumb.jpg');
+    $heroClasses = 'container-xxl py-5 hero-header mb-5' . ($heroMaskEnabled ? ' bg-dark' : '');
+    if (! $heroMaskEnabled) {
+        $heroClasses .= ' hero-no-mask';
+    }
+    $heroStyle = "background-image: url('{$heroBackground}'); background-size: cover; background-position: center;";
+
+    function restoran_article_image($path) {
+        if (empty($path)) {
+            return null;
+        }
+        if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://')) {
+            return $path;
+        }
+        return asset('storage/' . ltrim($path, '/'));
+    }
+@endphp
+<div class="container-xxl position-relative p-0">
+    {!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+        'brand' => $navigation['brand'],
+        'links' => $navigation['links'],
+        'showCart' => $navigation['show_cart'],
+        'showLogin' => $navigation['show_login'],
+        'cart' => $cartSummary,
+    ])->render() !!}
+    @if(($settings['hero.visible'] ?? '1') == '1')
+    <div id="hero" class="{{ $heroClasses }}" style="{{ $heroStyle }}">
+        <div class="container text-center my-5 pt-5 pb-4">
+            <h1 class="display-3 text-white mb-3">{{ $settings['hero.heading'] ?? 'Artikel' }}</h1>
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb justify-content-center text-uppercase">
+                    <li class="breadcrumb-item"><a href="{{ url('/') }}">Home</a></li>
+                    <li class="breadcrumb-item text-white active" aria-current="page">{{ $settings['hero.heading'] ?? 'Artikel' }}</li>
+                </ol>
+            </nav>
+            @if(!empty($settings['hero.description']))
+                <p class="text-white-50 mb-0">{{ $settings['hero.description'] }}</p>
+            @endif
+        </div>
+    </div>
+    @endif
+</div>
+
+<div id="list" class="container py-5">
+    <div class="row g-5">
+        <div class="col-lg-8">
+            @forelse($articles as $article)
+            <div class="card border-0 shadow-sm mb-4">
+                @php $image = restoran_article_image($article['image'] ?? null); @endphp
+                @if($image)
+                    <img src="{{ $image }}" class="card-img-top" alt="{{ $article['title'] ?? 'Artikel' }}">
+                @endif
+                <div class="card-body p-4">
+                    <div class="d-flex align-items-center text-muted mb-2 small">
+                        @if(!empty($article['date_formatted']))
+                            <span class="me-3"><i class="far fa-calendar-alt me-1"></i>{{ $article['date_formatted'] }}</span>
+                        @endif
+                        @if(!empty($article['author']))
+                            <span><i class="far fa-user me-1"></i>{{ $article['author'] }}</span>
+                        @endif
+                    </div>
+                    <h3 class="card-title h4">{{ $article['title'] ?? 'Artikel' }}</h3>
+                    @if(!empty($article['excerpt']))
+                        <p class="card-text">{{ $article['excerpt'] }}</p>
+                    @endif
+                    <a href="{{ route('articles.show', ['slug' => $article['slug']]) }}" class="btn btn-sm btn-primary">{{ $buttonLabel }}</a>
+                </div>
+            </div>
+            @empty
+            <div class="alert alert-light border">{{ $emptyText }}</div>
+            @endforelse
+        </div>
+        <div class="col-lg-4">
+            <div id="search" class="card border-0 shadow-sm mb-4">
+                <div class="card-body">
+                    <h4 class="card-title">Cari Artikel</h4>
+                    <form method="GET" class="d-flex flex-column gap-3">
+                        <input type="hidden" name="year" value="{{ request('year') }}">
+                        <input type="hidden" name="month" value="{{ request('month') }}">
+                        <input type="text" name="search" class="form-control" placeholder="{{ $searchPlaceholder }}" value="{{ request('search') }}">
+                        <button type="submit" class="btn btn-primary">Cari</button>
+                    </form>
+                    @if(request()->filled('search') || request()->filled('year') || request()->filled('month'))
+                        <a href="{{ route('articles.index') }}" class="btn btn-link px-0 mt-3">Reset Filter</a>
+                    @endif
+                </div>
+            </div>
+            @if(($settings['timeline.visible'] ?? '1') == '1')
+            <div id="timeline" class="card border-0 shadow-sm">
+                <div class="card-body">
+                    <h4 class="card-title">{{ $settings['timeline.heading'] ?? 'Arsip' }}</h4>
+                    @if($timeline->isEmpty())
+                        <p class="text-muted mb-0">Belum ada arsip.</p>
+                    @else
+                        <div class="accordion" id="timelineAccordion">
+                            @foreach($timeline as $year => $months)
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="heading-{{ $year }}">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ $year }}" aria-expanded="false" aria-controls="collapse-{{ $year }}">
+                                            {{ $year }}
+                                        </button>
+                                    </h2>
+                                    <div id="collapse-{{ $year }}" class="accordion-collapse collapse" aria-labelledby="heading-{{ $year }}" data-bs-parent="#timelineAccordion">
+                                        <div class="accordion-body">
+                                            @foreach($months as $monthKey => $monthData)
+                                                <div class="mb-3">
+                                                    <a href="{{ route('articles.index', ['year' => $year, 'month' => $monthKey]) }}" class="fw-semibold d-block">{{ $monthData['name'] ?? $monthKey }} ({{ $monthData['articles']->count() }})</a>
+                                                    <ul class="list-unstyled ms-3 mt-2">
+                                                        @foreach($monthData['articles'] as $item)
+                                                            <li class="mb-1"><a href="{{ route('articles.show', ['slug' => $item['slug']]) }}" class="text-decoration-none"><i class="far fa-file-alt me-2 text-primary"></i>{{ $item['title'] ?? 'Artikel' }}</a></li>
+                                                        @endforeach
+                                                    </ul>
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            </div>
+            @endif
+        </div>
+    </div>
+</div>
+
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/wow/wow.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/easing/easing.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/waypoints/waypoints.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/counterup/counterup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/owlcarousel/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/moment-timezone.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/lib/tempusdominus/js/tempusdominus-bootstrap-4.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-restoran/js/main.js') }}"></script>
+</body>
+</html>

--- a/themes/theme-second/views/article-detail.blade.php
+++ b/themes/theme-second/views/article-detail.blade.php
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ $pageTitle ?? 'Artikel' }}</title>
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/bootstrap.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/font-awesome.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/elegant-icons.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/nice-select.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/owl.carousel.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/slicknav.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/style.css') }}" type="text/css">
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+    use Illuminate\Support\Carbon;
+
+    $themeName = $theme ?? 'theme-second';
+    $detailSettings = PageSetting::forPage('article-detail');
+    $listSettings = PageSetting::forPage('article');
+
+    $rawArticles = collect($articles ?? json_decode($listSettings['articles.items'] ?? '[]', true));
+    $preparedArticles = $rawArticles->filter(function ($item) {
+        return !empty($item['slug']);
+    })->map(function ($item) {
+        $date = null;
+        if (!empty($item['date'])) {
+            try {
+                $date = Carbon::parse($item['date']);
+            } catch (\Exception $e) {
+                $date = null;
+            }
+        }
+        $item['date_object'] = $date;
+        $item['date_formatted'] = $date ? $date->locale(app()->getLocale())->isoFormat('D MMMM Y') : null;
+        return $item;
+    });
+
+    $currentSlug = $article['slug'] ?? null;
+    $current = $preparedArticles->firstWhere('slug', $currentSlug) ?? $article;
+
+    if (!is_array($current)) {
+        $current = (array) $current;
+    }
+
+    $dateObject = null;
+    if (!empty($current['date_object'])) {
+        $dateObject = $current['date_object'];
+    } elseif (!empty($current['date'])) {
+        try {
+            $dateObject = Carbon::parse($current['date']);
+        } catch (\Exception $e) {
+            $dateObject = null;
+        }
+    }
+
+    $dateFormatted = $dateObject ? $dateObject->locale(app()->getLocale())->isoFormat('D MMMM Y') : null;
+
+    $pageTitle = $current['title'] ?? 'Artikel';
+
+    $recommended = $preparedArticles->filter(function ($item) use ($currentSlug) {
+        return $item['slug'] !== $currentSlug;
+    })->sortByDesc(function ($item) {
+        return optional($item['date_object'])->timestamp ?? 0;
+    })->take(3);
+
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
+    $cartSummary = Cart::summary();
+
+    function article_image_path($path) {
+        if (empty($path)) {
+            return null;
+        }
+        if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://')) {
+            return $path;
+        }
+        return asset('storage/' . ltrim($path, '/'));
+    }
+@endphp
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
+
+@if(($detailSettings['hero.visible'] ?? '1') == '1')
+<section id="hero" class="breadcrumb-section set-bg {{ ($detailSettings['hero.mask'] ?? '0') == '1' ? 'breadcrumb-section--mask' : '' }}" data-setbg="{{ !empty($detailSettings['hero.image']) ? asset('storage/'.$detailSettings['hero.image']) : asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <div class="breadcrumb__text">
+                    <h2>{{ $current['title'] ?? ($detailSettings['hero.title'] ?? 'Artikel') }}</h2>
+                    <div class="breadcrumb__option">
+                        <a href="{{ url('/') }}">Home</a>
+                        <a href="{{ route('articles.index') }}">Artikel</a>
+                        <span>{{ $detailSettings['hero.title'] ?? ($current['title'] ?? 'Detail Artikel') }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endif
+
+<section id="content" class="blog-details spad">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 col-md-8">
+                <div class="blog__details__text">
+                    @php $image = article_image_path($current['image'] ?? null); @endphp
+                    @if($image)
+                        <img src="{{ $image }}" alt="{{ $current['title'] ?? 'Artikel' }}" class="img-fluid mb-4">
+                    @endif
+                    <h2>{{ $current['title'] ?? 'Artikel' }}</h2>
+                    <ul class="blog__details__author">
+                        @if(($detailSettings['meta.show_author'] ?? '1') == '1' && !empty($current['author']))
+                            <li><i class="fa fa-user"></i> {{ $current['author'] }}</li>
+                        @endif
+                        @if(($detailSettings['meta.show_date'] ?? '1') == '1' && $dateFormatted)
+                            <li><i class="fa fa-calendar-o"></i> {{ $dateFormatted }}</li>
+                        @endif
+                    </ul>
+                    <div class="blog__details__content">
+                        {!! $current['content'] ?? '<p>Konten artikel belum tersedia.</p>' !!}
+                    </div>
+                </div>
+
+                <div id="comments" class="blog__details__comment mt-5">
+                    @if(($detailSettings['comments.visible'] ?? '1') == '1')
+                        <h4>{{ $detailSettings['comments.heading'] ?? 'Komentar' }}</h4>
+                        <p class="text-muted">Fitur komentar akan segera hadir.</p>
+                    @else
+                        <div class="alert alert-light border">{{ $detailSettings['comments.disabled_text'] ?? 'Komentar dinonaktifkan.' }}</div>
+                    @endif
+                </div>
+            </div>
+            <div class="col-lg-4 col-md-4">
+                @if(($detailSettings['recommendations.visible'] ?? '1') == '1' && $recommended->isNotEmpty())
+                <div id="recommendations" class="blog__sidebar">
+                    <div class="blog__sidebar__item">
+                        <h4>{{ $detailSettings['recommendations.heading'] ?? 'Artikel Lainnya' }}</h4>
+                        <div class="blog__sidebar__recent">
+                            @foreach($recommended as $item)
+                                <a href="{{ route('articles.show', ['slug' => $item['slug']]) }}" class="blog__sidebar__recent__item">
+                                    <h6>{{ $item['title'] ?? 'Artikel' }}</h6>
+                                    <span>{{ $item['date_formatted'] ?? '' }}</span>
+                                </a>
+                            @endforeach
+                        </div>
+                    </div>
+                </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</section>
+
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+<script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.nice-select.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery-ui.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.slicknav.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/mixitup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/main.js') }}"></script>
+
+@once
+    <style>
+        .breadcrumb-section--mask::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.45);
+        }
+        .blog__details__author {
+            list-style: none;
+            padding: 0;
+            margin: 1rem 0;
+            display: flex;
+            gap: 1.5rem;
+        }
+        .blog__details__author li {
+            color: #6c757d;
+            font-size: 0.95rem;
+        }
+        .blog__details__author i {
+            margin-right: 0.5rem;
+        }
+        .blog__details__content p {
+            margin-bottom: 1.5rem;
+            line-height: 1.7;
+        }
+    </style>
+@endonce
+</body>
+</html>

--- a/themes/theme-second/views/article.blade.php
+++ b/themes/theme-second/views/article.blade.php
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ $pageTitle ?? 'Artikel' }}</title>
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/bootstrap.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/font-awesome.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/elegant-icons.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/nice-select.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/owl.carousel.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/slicknav.min.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('storage/themes/theme-second/css/style.css') }}" type="text/css">
+</head>
+<body>
+@php
+    use App\Models\PageSetting;
+    use App\Support\Cart;
+    use App\Support\LayoutSettings;
+    use Illuminate\Support\Carbon;
+
+    $themeName = $theme ?? 'theme-second';
+    $settings = PageSetting::forPage('article');
+    $rawArticles = collect(json_decode($settings['articles.items'] ?? '[]', true));
+
+    $allArticles = $rawArticles->filter(function ($item) {
+        return !empty($item['slug']);
+    })->map(function ($item) {
+        $date = null;
+        if (!empty($item['date'])) {
+            try {
+                $date = Carbon::parse($item['date']);
+            } catch (\Exception $e) {
+                $date = null;
+            }
+        }
+        $item['date_object'] = $date;
+        $item['date_formatted'] = $date ? $date->locale(app()->getLocale())->isoFormat('D MMMM Y') : null;
+        $item['year'] = $date ? (int) $date->format('Y') : null;
+        $item['month'] = $date ? $date->format('m') : null;
+        $item['month_name'] = $date ? $date->locale(app()->getLocale())->isoFormat('MMMM') : null;
+        return $item;
+    });
+
+    $timeline = $allArticles->filter(fn ($item) => $item['year'] && $item['month'])->groupBy('year')->sortKeysDesc()->map(function ($group) {
+        return $group->groupBy('month')->sortKeysDesc()->map(function ($monthGroup) {
+            $first = $monthGroup->first();
+            return [
+                'name' => $first['month_name'] ?? '',
+                'articles' => $monthGroup->sortByDesc(function ($article) {
+                    return optional($article['date_object'])->timestamp ?? 0;
+                })->values(),
+            ];
+        });
+    });
+
+    $articles = $allArticles;
+
+    if ($search = trim(request('search', ''))) {
+        $lower = mb_strtolower($search);
+        $articles = $articles->filter(function ($item) use ($lower) {
+            $haystack = mb_strtolower(($item['title'] ?? '') . ' ' . ($item['excerpt'] ?? '') . ' ' . ($item['content'] ?? ''));
+            return str_contains($haystack, $lower);
+        });
+    }
+
+    if ($yearFilter = request('year')) {
+        $articles = $articles->filter(fn ($item) => (string) ($item['year'] ?? '') === (string) $yearFilter);
+    }
+
+    if ($monthFilter = request('month')) {
+        $monthFilter = str_pad($monthFilter, 2, '0', STR_PAD_LEFT);
+        $articles = $articles->filter(fn ($item) => ($item['month'] ?? '') === $monthFilter);
+    }
+
+    $articles = $articles->sortByDesc(function ($article) {
+        return optional($article['date_object'])->timestamp ?? 0;
+    })->values();
+
+    $navigation = LayoutSettings::navigation($themeName);
+    $footerConfig = LayoutSettings::footer($themeName);
+    $cartSummary = Cart::summary();
+
+    $pageTitle = $settings['hero.heading'] ?? 'Artikel';
+    $buttonLabel = $settings['list.button_label'] ?? 'Baca Selengkapnya';
+    $emptyText = $settings['list.empty_text'] ?? 'Belum ada artikel untuk ditampilkan.';
+    $searchPlaceholder = $settings['search.placeholder'] ?? 'Cari artikel...';
+
+    function article_image_path($path) {
+        if (empty($path)) {
+            return null;
+        }
+        if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://')) {
+            return $path;
+        }
+        return asset('storage/' . ltrim($path, '/'));
+    }
+@endphp
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
+
+@if(($settings['hero.visible'] ?? '1') == '1')
+<section id="hero" class="breadcrumb-section set-bg {{ ($settings['hero.mask'] ?? '0') == '1' ? 'breadcrumb-section--mask' : '' }}" data-setbg="{{ !empty($settings['hero.image']) ? asset('storage/'.$settings['hero.image']) : asset('storage/themes/theme-second/img/breadcrumb.jpg') }}">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <div class="breadcrumb__text">
+                    <h2>{{ $settings['hero.heading'] ?? 'Artikel' }}</h2>
+                    <div class="breadcrumb__option">
+                        <a href="{{ url('/') }}">Home</a>
+                        <span>{{ $settings['hero.heading'] ?? 'Artikel' }}</span>
+                    </div>
+                    @if(!empty($settings['hero.description']))
+                        <p class="mt-3 text-white-50">{{ $settings['hero.description'] }}</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+@endif
+
+<section id="list" class="blog spad">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 col-md-8">
+                @forelse($articles as $article)
+                <div class="blog__item">
+                    <div class="blog__item__pic">
+                        @php $image = article_image_path($article['image'] ?? null); @endphp
+                        <img src="{{ $image ?? asset('storage/themes/theme-second/img/blog/blog-1.jpg') }}" alt="{{ $article['title'] ?? 'Artikel' }}">
+                    </div>
+                    <div class="blog__item__text">
+                        <ul>
+                            @if(!empty($article['author']))
+                                <li><i class="fa fa-user"></i> {{ $article['author'] }}</li>
+                            @endif
+                            @if(!empty($article['date_formatted']))
+                                <li><i class="fa fa-calendar-o"></i> {{ $article['date_formatted'] }}</li>
+                            @endif
+                        </ul>
+                        <h5><a href="{{ route('articles.show', ['slug' => $article['slug']]) }}">{{ $article['title'] ?? 'Tanpa Judul' }}</a></h5>
+                        @if(!empty($article['excerpt']))
+                            <p>{{ $article['excerpt'] }}</p>
+                        @endif
+                        <a href="{{ route('articles.show', ['slug' => $article['slug']]) }}" class="blog__btn">{{ $buttonLabel }} <span class="arrow_right"></span></a>
+                    </div>
+                </div>
+                @empty
+                <div class="alert alert-light border">
+                    {{ $emptyText }}
+                </div>
+                @endforelse
+            </div>
+            <div class="col-lg-4 col-md-4">
+                <div class="blog__sidebar">
+                    <div id="search" class="blog__sidebar__search">
+                        <form method="GET">
+                            <input type="hidden" name="year" value="{{ request('year') }}">
+                            <input type="hidden" name="month" value="{{ request('month') }}">
+                            <input type="text" name="search" placeholder="{{ $searchPlaceholder }}" value="{{ request('search') }}">
+                            <button type="submit"><span class="icon_search"></span></button>
+                        </form>
+                    </div>
+                    @if(request()->filled('year') || request()->filled('month') || request()->filled('search'))
+                        <div class="blog__sidebar__item">
+                            <a href="{{ route('articles.index') }}" class="site-btn w-100 text-center">Reset Filter</a>
+                        </div>
+                    @endif
+                    @if(($settings['timeline.visible'] ?? '1') == '1')
+                    <div id="timeline" class="blog__sidebar__item">
+                        <h4>{{ $settings['timeline.heading'] ?? 'Arsip Artikel' }}</h4>
+                        @if($timeline->isEmpty())
+                            <p class="text-muted mb-0">Belum ada arsip.</p>
+                        @else
+                        <div class="blog__sidebar__item__categories">
+                            <ul>
+                                @foreach($timeline as $year => $months)
+                                    <li>
+                                        <span class="d-block fw-bold">{{ $year }}</span>
+                                        <ul class="list-unstyled ms-3 mt-2">
+                                            @foreach($months as $monthKey => $monthData)
+                                                <li class="mb-2">
+                                                    <a href="{{ route('articles.index', ['year' => $year, 'month' => $monthKey]) }}" class="d-block">
+                                                        {{ $monthData['name'] ?? $monthKey }} ({{ $monthData['articles']->count() }})
+                                                    </a>
+                                                    <ul class="list-unstyled ms-3 mt-1">
+                                                        @foreach($monthData['articles'] as $item)
+                                                            <li><a href="{{ route('articles.show', ['slug' => $item['slug']]) }}">{{ $item['title'] ?? 'Artikel' }}</a></li>
+                                                        @endforeach
+                                                    </ul>
+                                                </li>
+                                            @endforeach
+                                        </ul>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                        @endif
+                    </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+{!! view()->file(base_path('themes/' . $themeName . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+<script src="{{ asset('storage/themes/theme-second/js/jquery-3.3.1.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/bootstrap.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.nice-select.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery-ui.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/jquery.slicknav.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/mixitup.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/owl.carousel.min.js') }}"></script>
+<script src="{{ asset('storage/themes/theme-second/js/main.js') }}"></script>
+
+@once
+    <style>
+        .breadcrumb-section--mask::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.45);
+        }
+        .blog__sidebar__item__categories > ul > li {
+            margin-bottom: 1.5rem;
+        }
+        .blog__sidebar__item__categories ul ul li {
+            font-size: 0.95rem;
+        }
+    </style>
+@endonce
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose `/artikel` and `/artikel/{slug}` routes that render the active theme's listing/detail views with PageSetting-backed data
- add Kelola Halaman screens for configuring article list, timeline, metadata, comments, and recommendations
- build article and article-detail templates for the herbalgreen, second, and restoran themes with search, archives, and related content blocks

## Testing
- `php artisan test` *(fails: missing `vendor/autoload.php` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da82ebf62483298cc8ca5022c8f285