### PR TITLE
Add admin AI settings and article generation support

### DIFF
--- a/app/Http/Controllers/Admin/AiSettingController.php
+++ b/app/Http/Controllers/Admin/AiSettingController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AiSetting;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class AiSettingController extends Controller
+{
+    /**
+     * Display AI configuration dashboard.
+     */
+    public function index(): View
+    {
+        $sections = AiSetting::sections();
+
+        $settings = $sections->mapWithKeys(function ($meta, $section) {
+            return [$section => AiSetting::forSection($section)];
+        });
+
+        return view('admin.ai.settings', [
+            'sections' => $sections,
+            'settings' => $settings,
+        ]);
+    }
+
+    /**
+     * Update AI settings for a specific section.
+     */
+    public function update(Request $request, string $section): RedirectResponse
+    {
+        abort_unless(AiSetting::isValidSection($section), 404);
+
+        $setting = AiSetting::forSection($section);
+
+        $validated = $request->validate([
+            'model' => ['required', 'string', 'max:255'],
+            'temperature' => ['nullable', 'numeric', 'between:0,2'],
+            'max_tokens' => ['nullable', 'integer', 'min:1', 'max:128000'],
+            'top_p' => ['nullable', 'numeric', 'between:0,1'],
+            'frequency_penalty' => ['nullable', 'numeric', 'between:-2,2'],
+            'presence_penalty' => ['nullable', 'numeric', 'between:-2,2'],
+        ]);
+
+        $cleaned = collect($validated)
+            ->map(fn ($value) => ($value === '' ? null : $value))
+            ->all();
+
+        $setting->fill($cleaned);
+        $setting->save();
+
+        return redirect()
+            ->route('admin.ai-settings.index')
+            ->with('success', 'Pengaturan AI berhasil diperbarui untuk "' . ($request->input('section_label') ?? $section) . '".');
+    }
+}

--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\Article;
+use App\Services\AI\ArticleGenerator;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
@@ -89,6 +91,27 @@ class ArticleController extends Controller
         return view('admin.articles.edit', [
             'article' => $article,
         ]);
+    }
+
+    public function generateWithAi(Request $request, ArticleGenerator $generator): JsonResponse
+    {
+        $validated = $request->validate([
+            'keywords' => ['required', 'string', 'max:255'],
+        ]);
+
+        try {
+            $data = $generator->generate($validated['keywords']);
+
+            return response()->json([
+                'data' => $data,
+            ]);
+        } catch (\Throwable $exception) {
+            report($exception);
+
+            return response()->json([
+                'message' => $exception->getMessage(),
+            ], 422);
+        }
     }
 
     public function update(Request $request, Article $article): RedirectResponse

--- a/app/Models/AiSetting.php
+++ b/app/Models/AiSetting.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+class AiSetting extends Model
+{
+    use HasFactory;
+
+    public const PROVIDER_OPENAI = 'openai';
+
+    public const SECTION_ARTICLE_GENERATION = 'article_generation';
+    public const SECTION_REPORT_READER = 'report_reader';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $fillable = [
+        'section',
+        'provider',
+        'model',
+        'temperature',
+        'max_tokens',
+        'top_p',
+        'frequency_penalty',
+        'presence_penalty',
+        'extra_settings',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $casts = [
+        'temperature' => 'float',
+        'max_tokens' => 'integer',
+        'top_p' => 'float',
+        'frequency_penalty' => 'float',
+        'presence_penalty' => 'float',
+        'extra_settings' => 'array',
+    ];
+
+    /**
+     * Return known AI sections with their labels and descriptions.
+     */
+    public static function sections(): Collection
+    {
+        return collect([
+            self::SECTION_ARTICLE_GENERATION => [
+                'label' => 'Generator Artikel SEO',
+                'description' => 'Atur parameter untuk pembuatan artikel otomatis yang mengoptimalkan SEO dan pengalaman pembaca.',
+            ],
+            self::SECTION_REPORT_READER => [
+                'label' => 'Pembaca Laporan (Coming Soon)',
+                'description' => 'Siapkan parameter AI yang kelak digunakan untuk menganalisis dan merangkum laporan bisnis.',
+            ],
+        ]);
+    }
+
+    /**
+     * Determine whether the given section is supported.
+     */
+    public static function isValidSection(string $section): bool
+    {
+        return self::sections()->keys()->contains($section);
+    }
+
+    /**
+     * Retrieve the AI setting for a section and ensure defaults are populated.
+     */
+    public static function forSection(string $section): self
+    {
+        if (! self::isValidSection($section)) {
+            abort(404, 'AI section not found.');
+        }
+
+        $defaults = self::defaultAttributesForSection($section);
+
+        return static::firstOrCreate(
+            ['section' => $section],
+            $defaults
+        );
+    }
+
+    /**
+     * Default attributes used when creating a section for the first time.
+     */
+    protected static function defaultAttributesForSection(string $section): array
+    {
+        return match ($section) {
+            self::SECTION_REPORT_READER => [
+                'provider' => self::PROVIDER_OPENAI,
+                'model' => 'gpt-4o-mini',
+                'temperature' => 0.3,
+                'max_tokens' => 1500,
+                'top_p' => 1.0,
+                'frequency_penalty' => 0.0,
+                'presence_penalty' => 0.0,
+                'extra_settings' => [],
+            ],
+            default => [
+                'provider' => self::PROVIDER_OPENAI,
+                'model' => 'gpt-4o-mini',
+                'temperature' => 0.7,
+                'max_tokens' => 2048,
+                'top_p' => 1.0,
+                'frequency_penalty' => 0.0,
+                'presence_penalty' => 0.0,
+                'extra_settings' => [],
+            ],
+        };
+    }
+}

--- a/app/Services/AI/ArticleGenerator.php
+++ b/app/Services/AI/ArticleGenerator.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Services\AI;
+
+use App\Models\AiSetting;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class ArticleGenerator
+{
+    /**
+     * Generate article content based on supplied keywords.
+     */
+    public function generate(string $keywords): array
+    {
+        $keywords = trim($keywords);
+
+        if ($keywords === '') {
+            throw new RuntimeException('Kata kunci tidak boleh kosong.');
+        }
+
+        $setting = AiSetting::forSection(AiSetting::SECTION_ARTICLE_GENERATION);
+
+        $apiKey = config('services.openai.api_key');
+
+        if (! $apiKey) {
+            throw new RuntimeException('Kunci API OpenAI belum dikonfigurasi.');
+        }
+
+        $clientOptions = array_filter([
+            'organization' => config('services.openai.organization'),
+        ]);
+
+        $client = \OpenAI::client($apiKey, $clientOptions);
+
+        $messages = [
+            [
+                'role' => 'system',
+                'content' => 'Anda adalah asisten penulisan konten SEO berbahasa Indonesia untuk brand e-commerce. Fokus pada kualitas, orisinalitas, dan kepatuhan terhadap praktik SEO terbaru.',
+            ],
+            [
+                'role' => 'user',
+                'content' => $this->buildPrompt($keywords),
+            ],
+        ];
+
+        $payload = array_filter([
+            'model' => $setting->model ?: 'gpt-4o-mini',
+            'messages' => $messages,
+            'temperature' => $setting->temperature,
+            'max_tokens' => $setting->max_tokens,
+            'top_p' => $setting->top_p,
+            'frequency_penalty' => $setting->frequency_penalty,
+            'presence_penalty' => $setting->presence_penalty,
+        ], fn ($value) => $value !== null && $value !== '');
+
+        $response = $client->chat()->create($payload);
+
+        $content = trim($response->choices[0]->message->content ?? '');
+
+        $decoded = json_decode($content, true);
+
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Respons AI tidak dapat dipahami. Pastikan parameter yang digunakan sudah benar.');
+        }
+
+        $title = trim((string) ($decoded['title'] ?? ''));
+
+        if ($title === '') {
+            throw new RuntimeException('AI tidak menghasilkan judul artikel.');
+        }
+
+        $slugSource = trim((string) ($decoded['slug'] ?? $title));
+        $slug = Str::slug($slugSource !== '' ? $slugSource : $title);
+
+        return [
+            'title' => $title,
+            'slug' => $slug,
+            'excerpt' => trim((string) ($decoded['excerpt'] ?? '')),
+            'content' => trim((string) ($decoded['content'] ?? '')),
+            'meta_title' => trim((string) ($decoded['meta_title'] ?? Str::limit($title, 60, ''))),
+            'meta_description' => trim((string) ($decoded['meta_description'] ?? '')),
+        ];
+    }
+
+    /**
+     * Build the detailed prompt for the AI model.
+     */
+    protected function buildPrompt(string $keywords): string
+    {
+        $keywords = trim($keywords);
+
+        return <<<PROMPT
+Anda diminta membuat satu artikel blog berbahasa Indonesia untuk toko online. Terapkan praktik terbaik SEO terkini dan optimasi pengalaman pembaca.
+
+Target kata kunci utama dan variasinya: {$keywords}.
+
+Persyaratan konten:
+1. Jumlah kata minimal 1.200 kata, dengan pembuka yang langsung menyinggung kata kunci utama.
+2. Gunakan struktur heading h2 dan h3 yang jelas, sertakan list bernomor atau bullet, dan tabel ringkasan bila relevan.
+3. Sisipkan kata kunci utama dan sinonimnya secara alami pada judul, subjudul penting, paragraf pertama, dan meta description tanpa keyword stuffing.
+4. Jelaskan topik secara mendalam dengan gaya profesional yang ramah, sertakan bukti sosial atau data pendukung jika memungkinkan, dan akhiri dengan ajakan bertindak yang kuat.
+5. Penuhi pedoman E-E-A-T (expertise, experience, authoritativeness, trustworthiness) serta hindari klaim berlebihan.
+6. Format konten menggunakan HTML sederhana (h2, h3, p, ul, ol, li, strong, em, table, thead, tbody, tr, th, td) agar siap ditempel ke CMS.
+7. Buat excerpt 30-40 kata yang merangkum artikel dan mengandung kata kunci utama.
+8. Pastikan meta title maksimal 60 karakter, meta description 150-160 karakter yang menggugah klik.
+9. Buat slug SEO-friendly seluruhnya huruf kecil, pisahkan kata dengan tanda hubung dan hindari karakter khusus.
+
+Berikan hasil akhir dalam JSON valid tanpa penjelasan tambahan dengan format persis berikut:
+{
+  "title": "...",
+  "slug": "...",
+  "excerpt": "...",
+  "content": "...",
+  "meta_title": "...",
+  "meta_description": "..."
+}
+PROMPT;
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -31,4 +31,9 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'organization' => env('OPENAI_ORGANIZATION'),
+    ],
+
 ];

--- a/database/migrations/2024_08_25_000000_create_ai_settings_table.php
+++ b/database/migrations/2024_08_25_000000_create_ai_settings_table.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ai_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('section')->unique();
+            $table->string('provider')->default('openai');
+            $table->string('model')->nullable();
+            $table->decimal('temperature', 4, 2)->nullable();
+            $table->unsignedInteger('max_tokens')->nullable();
+            $table->decimal('top_p', 4, 2)->nullable();
+            $table->decimal('frequency_penalty', 4, 2)->nullable();
+            $table->decimal('presence_penalty', 4, 2)->nullable();
+            $table->json('extra_settings')->nullable();
+            $table->timestamps();
+        });
+
+        DB::table('ai_settings')->insert([
+            [
+                'section' => 'article_generation',
+                'provider' => 'openai',
+                'model' => 'gpt-4o-mini',
+                'temperature' => 0.70,
+                'max_tokens' => 2048,
+                'top_p' => 1.00,
+                'frequency_penalty' => 0.00,
+                'presence_penalty' => 0.00,
+                'extra_settings' => json_encode([]),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'section' => 'report_reader',
+                'provider' => 'openai',
+                'model' => 'gpt-4o-mini',
+                'temperature' => 0.30,
+                'max_tokens' => 1500,
+                'top_p' => 1.00,
+                'frequency_penalty' => 0.00,
+                'presence_penalty' => 0.00,
+                'extra_settings' => json_encode([]),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_settings');
+    }
+};

--- a/resources/views/admin/ai/settings.blade.php
+++ b/resources/views/admin/ai/settings.blade.php
@@ -1,0 +1,109 @@
+@extends('layout.admin')
+
+@section('content')
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="page-header">
+      <h3 class="page-title">Pengaturan AI</h3>
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="{{ route('admin.dashboard') }}">Dasbor</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Pengaturan AI</li>
+        </ol>
+      </nav>
+    </div>
+
+    @if (session('success'))
+      <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+
+    @if ($errors->any())
+      <div class="alert alert-danger">
+        <strong>Terjadi kesalahan!</strong> Mohon periksa kembali input Anda.
+      </div>
+    @endif
+
+    @if (! config('services.openai.api_key'))
+      <div class="alert alert-warning">
+        <strong>Kunci API OpenAI belum terpasang.</strong> Tambahkan nilai <code>OPENAI_API_KEY</code> (dan bila perlu <code>OPENAI_ORGANIZATION</code>) pada file <code>.env</code> agar integrasi AI dapat digunakan.
+      </div>
+    @endif
+
+    <div class="row">
+      @foreach ($sections as $section => $meta)
+        @php
+          /** @var \App\Models\AiSetting $setting */
+          $setting = $settings[$section];
+        @endphp
+        <div class="col-lg-6 d-flex align-items-stretch">
+          <div class="card w-100 mb-4">
+            <div class="card-body d-flex flex-column">
+              <div class="mb-4">
+                <h4 class="card-title mb-1">{{ $meta['label'] }}</h4>
+                <p class="text-muted mb-0">{{ $meta['description'] }}</p>
+              </div>
+              <form method="POST" action="{{ route('admin.ai-settings.update', $section) }}" class="flex-grow-1 d-flex flex-column">
+                @csrf
+                @method('PUT')
+                <input type="hidden" name="section_label" value="{{ $meta['label'] }}">
+                <div class="form-group">
+                  <label for="model-{{ $section }}">Model</label>
+                  <input type="text" class="form-control @error('model') is-invalid @enderror" id="model-{{ $section }}" name="model" value="{{ old('model', $setting->model) }}" placeholder="mis. gpt-4o-mini">
+                  <small class="form-text text-muted">Tentukan model OpenAI yang ingin digunakan untuk proses ini.</small>
+                  @error('model')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                  @enderror
+                </div>
+                <div class="form-row">
+                  <div class="form-group col-md-6">
+                    <label for="temperature-{{ $section }}">Temperature</label>
+                    <input type="number" step="0.01" min="0" max="2" class="form-control @error('temperature') is-invalid @enderror" id="temperature-{{ $section }}" name="temperature" value="{{ old('temperature', $setting->temperature) }}" placeholder="0.7">
+                    <small class="form-text text-muted">Semakin tinggi nilainya semakin kreatif hasilnya.</small>
+                    @error('temperature')
+                      <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                  </div>
+                  <div class="form-group col-md-6">
+                    <label for="max_tokens-{{ $section }}">Max Tokens</label>
+                    <input type="number" min="1" max="128000" class="form-control @error('max_tokens') is-invalid @enderror" id="max_tokens-{{ $section }}" name="max_tokens" value="{{ old('max_tokens', $setting->max_tokens) }}" placeholder="2048">
+                    <small class="form-text text-muted">Batasi panjang jawaban yang diizinkan model.</small>
+                    @error('max_tokens')
+                      <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                  </div>
+                </div>
+                <div class="form-row">
+                  <div class="form-group col-md-4">
+                    <label for="top_p-{{ $section }}">Top P</label>
+                    <input type="number" step="0.01" min="0" max="1" class="form-control @error('top_p') is-invalid @enderror" id="top_p-{{ $section }}" name="top_p" value="{{ old('top_p', $setting->top_p) }}" placeholder="1">
+                    @error('top_p')
+                      <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                  </div>
+                  <div class="form-group col-md-4">
+                    <label for="frequency_penalty-{{ $section }}">Frequency Penalty</label>
+                    <input type="number" step="0.01" min="-2" max="2" class="form-control @error('frequency_penalty') is-invalid @enderror" id="frequency_penalty-{{ $section }}" name="frequency_penalty" value="{{ old('frequency_penalty', $setting->frequency_penalty) }}" placeholder="0">
+                    @error('frequency_penalty')
+                      <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                  </div>
+                  <div class="form-group col-md-4">
+                    <label for="presence_penalty-{{ $section }}">Presence Penalty</label>
+                    <input type="number" step="0.01" min="-2" max="2" class="form-control @error('presence_penalty') is-invalid @enderror" id="presence_penalty-{{ $section }}" name="presence_penalty" value="{{ old('presence_penalty', $setting->presence_penalty) }}" placeholder="0">
+                    @error('presence_penalty')
+                      <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                  </div>
+                </div>
+                <div class="mt-auto d-flex justify-content-end">
+                  <button type="submit" class="btn btn-primary">Simpan Pengaturan</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      @endforeach
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/admin/articles/_form.blade.php
+++ b/resources/views/admin/articles/_form.blade.php
@@ -6,6 +6,21 @@
   <div class="col-lg-8">
     <div class="card mb-4">
       <div class="card-body">
+        <h4 class="card-title">Asisten AI</h4>
+        <p class="text-muted">Masukkan kata kunci utama untuk menghasilkan draft artikel dan meta data secara otomatis. Hasil AI akan mengisi kolom formulir ini dan tetap dapat Anda sunting sebelum diterbitkan.</p>
+        <div class="form-group">
+          <label for="ai_keywords">Kata Kunci Target</label>
+          <input type="text" id="ai_keywords" name="ai_keywords" value="{{ old('ai_keywords') }}" class="form-control" placeholder="Contoh: manfaat teh hijau untuk kesehatan kulit">
+          <small class="form-text text-muted">Isi kata kunci utama dan variasinya (dipisahkan koma) untuk menggunakan fitur AI.</small>
+        </div>
+        <button type="button" class="btn btn-outline-primary" id="generate-with-ai">
+          <i class="mdi mdi-robot-outline mr-1"></i> Buat Konten dengan AI
+        </button>
+        <small id="generate-with-ai-status" class="form-text mt-2 text-muted"></small>
+      </div>
+    </div>
+    <div class="card mb-4">
+      <div class="card-body">
         <h4 class="card-title">Konten Artikel</h4>
         <div class="form-group">
           <label for="title">Judul<span class="text-danger">*</span></label>

--- a/resources/views/admin/articles/create.blade.php
+++ b/resources/views/admin/articles/create.blade.php
@@ -30,3 +30,7 @@
   </div>
 </div>
 @endsection
+
+@section('script')
+  @include('admin.articles.partials.ai-script')
+@endsection

--- a/resources/views/admin/articles/edit.blade.php
+++ b/resources/views/admin/articles/edit.blade.php
@@ -42,3 +42,7 @@
   </div>
 </div>
 @endsection
+
+@section('script')
+  @include('admin.articles.partials.ai-script')
+@endsection

--- a/resources/views/admin/articles/partials/ai-script.blade.php
+++ b/resources/views/admin/articles/partials/ai-script.blade.php
@@ -1,0 +1,84 @@
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const generateButton = document.getElementById('generate-with-ai');
+    const keywordsInput = document.getElementById('ai_keywords');
+    const statusElement = document.getElementById('generate-with-ai-status');
+
+    if (!generateButton || !keywordsInput || !statusElement) {
+      return;
+    }
+
+    const fields = {
+      title: document.getElementById('title'),
+      slug: document.getElementById('slug'),
+      excerpt: document.getElementById('excerpt'),
+      content: document.getElementById('content'),
+      meta_title: document.getElementById('meta_title'),
+      meta_description: document.getElementById('meta_description'),
+    };
+
+    const defaultButtonLabel = generateButton.innerHTML;
+
+    generateButton.addEventListener('click', async () => {
+      const keywords = keywordsInput.value.trim();
+
+      if (!keywords) {
+        statusElement.textContent = 'Masukkan minimal satu kata kunci untuk menggunakan AI.';
+        statusElement.classList.remove('text-muted', 'text-success');
+        statusElement.classList.add('text-danger');
+        keywordsInput.focus();
+        return;
+      }
+
+      const hasExistingContent = Object.values(fields).some((field) => field && field.value.trim().length > 0);
+
+      if (hasExistingContent) {
+        const confirmation = confirm('Konten yang sudah ada akan digantikan oleh hasil AI. Lanjutkan?');
+        if (!confirmation) {
+          return;
+        }
+      }
+
+      generateButton.disabled = true;
+      generateButton.innerHTML = '<span class="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>Meminta AI...';
+      statusElement.textContent = 'Sedang membuat artikel berbasis kata kunci Anda...';
+      statusElement.classList.remove('text-danger', 'text-success');
+      statusElement.classList.add('text-muted');
+
+      try {
+        const response = await fetch('{{ route('admin.articles.generate-ai') }}', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-CSRF-TOKEN': '{{ csrf_token() }}',
+          },
+          body: JSON.stringify({ keywords }),
+        });
+
+        const payload = await response.json();
+
+        if (!response.ok) {
+          throw new Error(payload.message || 'Gagal menghasilkan artikel dengan AI.');
+        }
+
+        Object.entries(payload.data || {}).forEach(([key, value]) => {
+          if (fields[key]) {
+            fields[key].value = value ?? '';
+          }
+        });
+
+        statusElement.textContent = 'Konten berhasil dihasilkan. Tinjau dan sesuaikan sebelum menerbitkan.';
+        statusElement.classList.remove('text-muted', 'text-danger');
+        statusElement.classList.add('text-success');
+      } catch (error) {
+        statusElement.textContent = error.message || 'Terjadi kesalahan saat berkomunikasi dengan AI.';
+        statusElement.classList.remove('text-muted', 'text-success');
+        statusElement.classList.add('text-danger');
+      } finally {
+        generateButton.disabled = false;
+        generateButton.innerHTML = defaultButtonLabel;
+      }
+    });
+  });
+</script>

--- a/resources/views/layout/admin.blade.php
+++ b/resources/views/layout/admin.blade.php
@@ -121,6 +121,19 @@
               <span class="menu-title">Tag Tema</span>
             </a>
           </li>
+          <li class="nav-item nav-category">Kecerdasan Buatan</li>
+          <li class="nav-item {{ request()->routeIs('admin.ai-settings.*') ? 'active' : '' }}">
+            <a class="nav-link" data-toggle="collapse" href="#ai-menu" aria-expanded="{{ request()->routeIs('admin.ai-settings.*') ? 'true' : 'false' }}" aria-controls="ai-menu">
+              <i class="mdi mdi-robot menu-icon"></i>
+              <span class="menu-title">AI</span>
+              <i class="menu-arrow"></i>
+            </a>
+            <div class="collapse {{ request()->routeIs('admin.ai-settings.*') ? 'show' : '' }}" id="ai-menu">
+              <ul class="nav flex-column sub-menu">
+                <li class="nav-item"><a class="nav-link" href="{{ route('admin.ai-settings.index') }}">Pengaturan AI</a></li>
+              </ul>
+            </div>
+          </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="collapse" href="#pages-menu" aria-expanded="false" aria-controls="pages-menu">
               <i class="mdi mdi-arrange-bring-forward menu-icon"></i>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\ThemeAssetController;
 use App\Http\Controllers\CartController;
 use App\Http\Controllers\Admin\ThemeController;
 use App\Http\Controllers\Admin\TagController;
+use App\Http\Controllers\Admin\AiSettingController;
 use App\Http\Controllers\Admin\ArticleController as AdminArticleController;
 use App\Http\Controllers\Admin\PaymentController;
 use App\Http\Controllers\Admin\ProductController;
@@ -150,7 +151,11 @@ Route::prefix('admin')->middleware(['auth'])->group(function () {
         Route::get('themes/preview/{theme}', [ThemeController::class, 'preview'])->name('admin.themes.preview');
 
         Route::resource('tags', TagController::class)->except(['show'])->names('admin.tags');
+        Route::post('articles/generate-with-ai', [AdminArticleController::class, 'generateWithAi'])->name('admin.articles.generate-ai');
         Route::resource('articles', AdminArticleController::class)->except(['show'])->names('admin.articles');
+
+        Route::get('ai/settings', [AiSettingController::class, 'index'])->name('admin.ai-settings.index');
+        Route::put('ai/settings/{section}', [AiSettingController::class, 'update'])->name('admin.ai-settings.update');
 
         Route::get('pages/home', [PageController::class, 'home'])->name('admin.pages.home');
         Route::post('pages/home', [PageController::class, 'updateHome'])->name('admin.pages.home.update');


### PR DESCRIPTION
## Summary
- add AI settings management in the admin panel with per-section OpenAI parameters
- create persistence and service layer for OpenAI-powered article generation
- enhance article forms with keyword input and "create with AI" workflow powered by stored settings

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2072f0008329bda38128fbe561a5