### PR TITLE
Fix AI article generator button on admin article form

### DIFF
--- a/resources/views/admin/articles/create.blade.php
+++ b/resources/views/admin/articles/create.blade.php
@@ -27,6 +27,10 @@
         <button type="submit" class="btn btn-primary">Publikasikan Artikel</button>
       </div>
     </form>
-  </div>
 </div>
+</div>
+@endsection
+
+@section('script')
+  @include('admin.articles.partials.ai-generator-script')
 @endsection

--- a/resources/views/admin/articles/edit.blade.php
+++ b/resources/views/admin/articles/edit.blade.php
@@ -39,6 +39,10 @@
         </div>
       </div>
     </form>
-  </div>
 </div>
+</div>
+@endsection
+
+@section('script')
+  @include('admin.articles.partials.ai-generator-script')
 @endsection

--- a/resources/views/admin/articles/partials/ai-generator-script.blade.php
+++ b/resources/views/admin/articles/partials/ai-generator-script.blade.php
@@ -1,0 +1,121 @@
+<script>
+(function () {
+  const button = document.getElementById('generate-with-ai');
+  const statusElement = document.getElementById('ai-status');
+  const keywordsInput = document.getElementById('ai_keywords');
+  const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+  const fields = {
+    title: document.getElementById('title'),
+    slug: document.getElementById('slug'),
+    excerpt: document.getElementById('excerpt'),
+    content: document.getElementById('content'),
+    meta_title: document.getElementById('meta_title'),
+    meta_description: document.getElementById('meta_description'),
+  };
+
+  if (!button || !keywordsInput) {
+    return;
+  }
+
+  let controller = null;
+  const originalButtonHtml = button.innerHTML;
+
+  const setButtonLoading = (isLoading) => {
+    button.disabled = isLoading;
+
+    if (isLoading) {
+      button.innerHTML = '<span class="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>Menghasilkan...';
+    } else {
+      button.innerHTML = originalButtonHtml;
+    }
+  };
+
+  const showStatus = (type, message) => {
+    if (!statusElement) {
+      return;
+    }
+
+    statusElement.classList.remove('d-none', 'alert-info', 'alert-success', 'alert-danger', 'alert-warning');
+    statusElement.classList.add(`alert-${type}`);
+    statusElement.textContent = message;
+  };
+
+  const handleError = (error) => {
+    const fallbackMessage = 'Terjadi kesalahan saat meminta AI. Silakan coba lagi.';
+    const message = typeof error === 'string' ? error : error?.message ?? fallbackMessage;
+    showStatus('danger', message);
+    console.error('[AI Generator] Error:', error);
+  };
+
+  button.addEventListener('click', async () => {
+    const keywords = keywordsInput.value.trim();
+
+    if (!keywords) {
+      showStatus('warning', 'Mohon isi kata kunci terlebih dahulu sebelum menggunakan AI.');
+      keywordsInput.focus();
+      return;
+    }
+
+    if (controller) {
+      controller.abort();
+    }
+
+    controller = new AbortController();
+    setButtonLoading(true);
+    showStatus('info', 'Sedang menghasilkan artikel dengan bantuan AI. Mohon tunggu sebentar...');
+
+    try {
+      const response = await fetch(@json(route('admin.ai.articles.generate')), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-CSRF-TOKEN': csrfToken,
+        },
+        body: JSON.stringify({ keywords }),
+        signal: controller.signal,
+      });
+
+      let payload = null;
+
+      try {
+        payload = await response.json();
+      } catch (jsonError) {
+        if (!response.ok) {
+          throw new Error('Gagal menghubungi layanan AI. Silakan periksa koneksi Anda.');
+        }
+      }
+
+      if (!response.ok) {
+        const validationErrors = payload?.errors ?? {};
+        const keywordsErrors = Array.isArray(validationErrors.keywords) ? validationErrors.keywords.join(' ') : null;
+        const message = keywordsErrors || payload?.message || 'Gagal menghasilkan artikel dari AI.';
+        throw new Error(message);
+      }
+
+      const data = payload?.data ?? {};
+
+      Object.entries(fields).forEach(([key, element]) => {
+        if (!element || typeof data[key] !== 'string') {
+          return;
+        }
+
+        element.value = data[key];
+        element.dispatchEvent(new Event('input'));
+        element.dispatchEvent(new Event('change'));
+      });
+
+      showStatus('success', 'Artikel berhasil dibuat oleh AI. Silakan tinjau dan sesuaikan sebelum menyimpan.');
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        return;
+      }
+
+      handleError(error);
+    } finally {
+      setButtonLoading(false);
+      controller = null;
+    }
+  });
+})();
+</script>


### PR DESCRIPTION
## Summary
- add a dedicated script partial that calls the AI article generation endpoint and writes the response into the form fields
- wire the script into both the create and edit article pages so the "Buat dengan AI" button becomes functional
- surface loading and error states to give admins feedback while waiting for AI responses

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68df4642ed808329bb6232e3234be444