### PR TITLE
Fix shipping navigation and gateway-specific views

### DIFF
--- a/app/Http/Controllers/Admin/OrderController.php
+++ b/app/Http/Controllers/Admin/OrderController.php
@@ -5,9 +5,14 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Order;
 use App\Models\Setting;
+use App\Services\Shipping\Exceptions\ShippingException;
+use App\Services\Shipping\ShippingGatewayManager;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\View\View;
+use Illuminate\Validation\Rule;
 
 class OrderController extends Controller
 {
@@ -42,5 +47,205 @@ class OrderController extends Controller
             : 'Pesanan ditandai belum diterima.';
 
         return redirect()->route('admin.orders.index')->with('success', $message);
+    }
+
+    public function updateShipping(Request $request, Order $order, ShippingGatewayManager $shipping): RedirectResponse
+    {
+        $shippingRecord = $order->shipping;
+        if (! $shippingRecord) {
+            return back()->with('error', 'Data pengiriman belum tersedia untuk pesanan ini.');
+        }
+
+        $data = $request->validate([
+            'courier' => ['nullable', 'string', 'max:50'],
+            'service' => ['nullable', 'string', 'max:100'],
+            'tracking_number' => ['nullable', 'string', 'max:100'],
+            'external_id' => ['nullable', 'string', 'max:100'],
+            'status' => ['nullable', Rule::in(['pending', 'packing', 'in_transit', 'delivered', 'cancelled'])],
+            'cost' => ['nullable', 'numeric', 'min:0'],
+            'estimated_delivery' => ['nullable', 'date'],
+        ]);
+
+        $shippingRecord->forceFill([
+            'courier' => $data['courier'] ?? $shippingRecord->courier,
+            'service' => $data['service'] ?? $shippingRecord->service,
+            'tracking_number' => $data['tracking_number'] ?? $shippingRecord->tracking_number,
+            'external_id' => $data['external_id'] ?? $shippingRecord->external_id,
+            'status' => $data['status'] ?? ($shippingRecord->status ?? 'pending'),
+            'cost' => array_key_exists('cost', $data) ? (float) $data['cost'] : $shippingRecord->cost,
+            'estimated_delivery' => $data['estimated_delivery'] ?? $shippingRecord->estimated_delivery,
+        ]);
+
+        $metadata = $shippingRecord->metadata ?? [];
+        data_set($metadata, 'manual.updated_at', now()->toIso8601String());
+        data_set($metadata, 'manual.updated_by', $request->user()?->id);
+        $shippingRecord->metadata = $metadata;
+
+        $shippingRecord->save();
+
+        return back()->with('success', 'Data pengiriman berhasil diperbarui.');
+    }
+
+    public function createShipping(Request $request, Order $order, ShippingGatewayManager $shipping): RedirectResponse
+    {
+        if (! $shipping->isEnabled()) {
+            return back()->with('error', 'Gateway pengiriman tidak aktif.');
+        }
+
+        $shippingRecord = $order->shipping;
+        if (! $shippingRecord) {
+            return back()->with('error', 'Data pengiriman belum tersedia untuk pesanan ini.');
+        }
+
+        $gateway = $shipping->getActive();
+        if (! $gateway || $shippingRecord->provider !== $gateway->key()) {
+            return back()->with('error', 'Pesanan ini tidak menggunakan gateway pengiriman yang aktif.');
+        }
+
+        $config = $shipping->getGatewayConfig($gateway->key());
+
+        try {
+            $response = $gateway->createShipment($config, [
+                'order' => $order->toArray(),
+                'shipping' => $shippingRecord->toArray(),
+                'contact' => Arr::get($shippingRecord->metadata, 'contact', []),
+                'address' => Arr::get($shippingRecord->metadata, 'address', []),
+                'selection' => Arr::get($shippingRecord->metadata, 'selection', []),
+            ]);
+        } catch (ShippingException $exception) {
+            return back()->with('error', $exception->getMessage());
+        }
+
+        $metadata = $shippingRecord->metadata ?? [];
+        data_set($metadata, 'gateway.last_action', 'create');
+        data_set($metadata, 'gateway.last_response', $response);
+        data_set($metadata, 'gateway.last_synced_at', now()->toIso8601String());
+
+        $shippingRecord->forceFill([
+            'status' => $response['status'] ?? ($shippingRecord->status ?: 'packing'),
+            'tracking_number' => $response['tracking_number'] ?? $shippingRecord->tracking_number,
+            'external_id' => $response['external_id'] ?? $shippingRecord->external_id,
+            'estimated_delivery' => $this->resolveEstimatedDelivery($response, $shippingRecord->estimated_delivery),
+            'metadata' => $metadata,
+        ])->save();
+
+        return back()->with('success', $response['message'] ?? 'Permintaan pengiriman dibuat.');
+    }
+
+    public function trackShipping(Request $request, Order $order, ShippingGatewayManager $shipping): RedirectResponse
+    {
+        if (! $shipping->isEnabled()) {
+            return back()->with('error', 'Gateway pengiriman tidak aktif.');
+        }
+
+        $shippingRecord = $order->shipping;
+        if (! $shippingRecord) {
+            return back()->with('error', 'Data pengiriman belum tersedia untuk pesanan ini.');
+        }
+
+        $data = $request->validate([
+            'tracking_number' => ['nullable', 'string', 'max:100'],
+            'courier' => ['nullable', 'string', 'max:50'],
+        ]);
+
+        $gateway = $shipping->getActive();
+        if (! $gateway || $shippingRecord->provider !== $gateway->key()) {
+            return back()->with('error', 'Pesanan ini tidak menggunakan gateway pengiriman yang aktif.');
+        }
+
+        $config = $shipping->getGatewayConfig($gateway->key());
+        $trackingNumber = $data['tracking_number'] ?: $shippingRecord->tracking_number;
+        $courier = $data['courier'] ?: $shippingRecord->courier;
+
+        if (! $trackingNumber) {
+            return back()->with('error', 'Nomor resi belum diatur.');
+        }
+
+        try {
+            $response = $gateway->trackShipment($config, [
+                'tracking_number' => $trackingNumber,
+                'courier' => $courier,
+                'awb' => $trackingNumber,
+            ]);
+        } catch (ShippingException $exception) {
+            return back()->with('error', $exception->getMessage());
+        }
+
+        $metadata = $shippingRecord->metadata ?? [];
+        data_set($metadata, 'tracking.summary', $response['summary'] ?? []);
+        data_set($metadata, 'tracking.details', $response['details'] ?? []);
+        data_set($metadata, 'tracking.delivery_status', $response['delivery_status'] ?? []);
+        data_set($metadata, 'tracking.manifest', $response['manifest'] ?? []);
+        data_set($metadata, 'tracking.checked_at', now()->toIso8601String());
+        data_set($metadata, 'gateway.last_action', 'track');
+        data_set($metadata, 'gateway.last_response', $response);
+        data_set($metadata, 'gateway.last_synced_at', now()->toIso8601String());
+
+        $shippingRecord->forceFill([
+            'tracking_number' => $trackingNumber,
+            'courier' => $courier ?: $shippingRecord->courier,
+            'status' => $response['status'] ?? ($shippingRecord->status ?? 'in_transit'),
+            'metadata' => $metadata,
+        ])->save();
+
+        return back()->with('success', 'Status pengiriman berhasil diperbarui.');
+    }
+
+    public function cancelShipping(Request $request, Order $order, ShippingGatewayManager $shipping): RedirectResponse
+    {
+        if (! $shipping->isEnabled()) {
+            return back()->with('error', 'Gateway pengiriman tidak aktif.');
+        }
+
+        $shippingRecord = $order->shipping;
+        if (! $shippingRecord) {
+            return back()->with('error', 'Data pengiriman belum tersedia untuk pesanan ini.');
+        }
+
+        $gateway = $shipping->getActive();
+        if (! $gateway || $shippingRecord->provider !== $gateway->key()) {
+            return back()->with('error', 'Pesanan ini tidak menggunakan gateway pengiriman yang aktif.');
+        }
+
+        $config = $shipping->getGatewayConfig($gateway->key());
+
+        try {
+            $response = $gateway->cancelShipment($config, [
+                'order' => $order->toArray(),
+                'shipping' => $shippingRecord->toArray(),
+            ]);
+        } catch (ShippingException $exception) {
+            return back()->with('error', $exception->getMessage());
+        }
+
+        $metadata = $shippingRecord->metadata ?? [];
+        data_set($metadata, 'gateway.last_action', 'cancel');
+        data_set($metadata, 'gateway.last_response', $response);
+        data_set($metadata, 'gateway.last_synced_at', now()->toIso8601String());
+
+        $shippingRecord->forceFill([
+            'status' => $response['status'] ?? 'cancelled',
+            'metadata' => $metadata,
+        ])->save();
+
+        return back()->with('success', $response['message'] ?? 'Pengiriman dibatalkan.');
+    }
+
+    protected function resolveEstimatedDelivery(array $response, $current)
+    {
+        $etd = Arr::get($response, 'estimated_delivery');
+        if (! $etd) {
+            $etd = Arr::get($response, 'etd');
+        }
+
+        if (! $etd) {
+            return $current;
+        }
+
+        try {
+            return Carbon::parse($etd);
+        } catch (\Throwable $exception) {
+            return $current;
+        }
     }
 }

--- a/app/Http/Controllers/Admin/ShippingController.php
+++ b/app/Http/Controllers/Admin/ShippingController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Setting;
+use App\Services\Shipping\ShippingGateway;
+use App\Services\Shipping\ShippingGatewayManager;
+use Creasi\Nusa\Models\Province;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+
+class ShippingController extends Controller
+{
+    public function index(Request $request, ShippingGatewayManager $shipping): View
+    {
+        $gateways = $shipping->all();
+        $configs = $shipping->getAllGatewayConfigs();
+        $activeKey = $shipping->getActiveKey();
+        $enabled = Setting::getValue('shipping.enabled', '0') === '1';
+        $provinces = Province::query()->orderBy('name')->get(['code', 'name']);
+
+        return view('admin.shipping.index', [
+            'gateways' => $gateways,
+            'configs' => $configs,
+            'activeKey' => $activeKey,
+            'enabled' => $enabled,
+            'provinces' => $provinces,
+        ]);
+    }
+
+    public function update(Request $request, ShippingGatewayManager $shipping): RedirectResponse
+    {
+        $gateways = $shipping->all();
+        $gatewayKeys = array_keys($gateways);
+
+        $validated = $request->validate([
+            'enabled' => ['nullable', 'boolean'],
+            'provider' => ['nullable', Rule::in($gatewayKeys)],
+        ]);
+
+        $enabled = (bool) ($validated['enabled'] ?? false);
+        $selectedProvider = $validated['provider'] ?? null;
+
+        if ($enabled && empty($selectedProvider)) {
+            return back()->withErrors(['provider' => 'Pilih gateway pengiriman untuk mengaktifkan layanan.']);
+        }
+
+        if ($enabled && $selectedProvider) {
+            /** @var ShippingGateway $gateway */
+            $gateway = $gateways[$selectedProvider];
+            $currentConfig = $shipping->getGatewayConfig($selectedProvider);
+
+            $configRules = [];
+            foreach ($gateway->configFields() as $field) {
+                $fieldKey = $field['key'];
+                $rule = $field['rules'] ?? 'nullable';
+                $hasStoredValue = array_key_exists($fieldKey, $currentConfig) && $currentConfig[$fieldKey];
+                if ($hasStoredValue) {
+                    $rule = str_replace('required', 'nullable', $rule);
+                }
+                $configRules['config.' . $fieldKey] = $rule;
+            }
+
+            $validated = $request->validate(array_merge([
+                'enabled' => ['nullable', 'boolean'],
+                'provider' => ['nullable', Rule::in($gatewayKeys)],
+            ], $configRules));
+
+            $configValues = [];
+            foreach ($gateway->configFields() as $field) {
+                $fieldKey = $field['key'];
+                $type = $field['type'] ?? 'text';
+                if (in_array($type, ['toggle', 'boolean', 'checkbox'], true)) {
+                    $configValues[$fieldKey] = $request->boolean('config.' . $fieldKey);
+                } else {
+                    $configValues[$fieldKey] = $validated['config'][$fieldKey] ?? ($currentConfig[$fieldKey] ?? null);
+                }
+            }
+
+            $shipping->storeProvider($selectedProvider);
+            $shipping->storeConfig($selectedProvider, $configValues);
+        }
+
+        $shipping->storeEnabled($enabled);
+
+        if (! $enabled) {
+            $shipping->storeProvider('');
+        }
+
+        return redirect()->route('admin.shipping.index')->with('success', 'Pengaturan pengiriman diperbarui.');
+    }
+}

--- a/app/Http/Controllers/ShippingController.php
+++ b/app/Http/Controllers/ShippingController.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Setting;
+use App\Services\Shipping\Exceptions\ShippingException;
+use App\Services\Shipping\ShippingGatewayManager;
+use App\Support\Cart;
+use App\Support\ShippingSession;
+use Creasi\Nusa\Models\Province;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\File;
+use Illuminate\View\View;
+
+class ShippingController extends Controller
+{
+    public function index(Request $request, ShippingGatewayManager $shipping): View|RedirectResponse
+    {
+        if (! $shipping->isEnabled()) {
+            return redirect()->route('checkout.payment');
+        }
+
+        $gateway = $shipping->getActive();
+        if (! $gateway) {
+            return redirect()->route('checkout.payment');
+        }
+
+        $cartSummary = Cart::summary();
+        if (empty($cartSummary['items'])) {
+            return redirect()->route('cart.index')->with('error', 'Keranjang Anda kosong.');
+        }
+
+        $theme = Setting::getValue('active_theme', 'theme-herbalgreen');
+        $gatewayKey = $gateway->key();
+        $viewCandidates = [
+            base_path("themes/{$theme}/views/shipping/{$gatewayKey}.blade.php"),
+            base_path("themes/{$theme}/views/shipping/default.blade.php"),
+            base_path("themes/{$theme}/views/shipping.blade.php"),
+        ];
+
+        $viewPath = collect($viewCandidates)->first(fn ($path) => File::exists($path));
+
+        if (! $viewPath) {
+            abort(404);
+        }
+
+        $provinces = Province::query()->orderBy('name')->get(['code', 'name'])->map(function ($province) {
+            return [
+                'code' => $province->code,
+                'name' => $province->name,
+            ];
+        });
+
+        return view()->file($viewPath, [
+            'theme' => $theme,
+            'gatewayKey' => $gatewayKey,
+            'cartSummary' => $cartSummary,
+            'provinces' => $provinces,
+            'shippingData' => ShippingSession::get(),
+        ]);
+    }
+
+    public function rates(Request $request, ShippingGatewayManager $shipping): JsonResponse
+    {
+        if (! $shipping->isEnabled()) {
+            return response()->json(['status' => 'error', 'message' => 'Pengiriman tidak aktif.'], 404);
+        }
+
+        $data = $request->validate([
+            'province_code' => ['required', 'string'],
+            'regency_code' => ['required', 'string'],
+            'district_code' => ['nullable', 'string'],
+            'postal_code' => ['nullable', 'string'],
+        ]);
+
+        $cartSummary = Cart::summary();
+        if (empty($cartSummary['items'])) {
+            return response()->json(['status' => 'error', 'message' => 'Keranjang kosong.'], 422);
+        }
+
+        $gateway = $shipping->getActive();
+        if (! $gateway) {
+            return response()->json(['status' => 'error', 'message' => 'Gateway pengiriman tidak tersedia.'], 404);
+        }
+
+        $config = $shipping->getGatewayConfig($gateway->key());
+        $destinationCode = $data['district_code'] ?: $data['regency_code'];
+        $destinationType = $data['district_code'] ? 'subdistrict' : 'city';
+
+        try {
+            $rates = $gateway->fetchRates($config, [
+                'destination' => [
+                    'code' => $destinationCode,
+                    'type' => $destinationType,
+                ],
+                'weight' => max(1, (int) ($cartSummary['total_weight_grams'] ?? 1)),
+            ]);
+        } catch (ShippingException $exception) {
+            return response()->json([
+                'status' => 'error',
+                'message' => $exception->getMessage(),
+            ], 422);
+        }
+
+        return response()->json([
+            'status' => 'ok',
+            'rates' => $rates,
+        ]);
+    }
+
+    public function store(Request $request, ShippingGatewayManager $shipping): RedirectResponse
+    {
+        if (! $shipping->isEnabled()) {
+            return redirect()->route('checkout.payment');
+        }
+
+        $cartSummary = Cart::summary();
+        if (empty($cartSummary['items'])) {
+            return redirect()->route('cart.index')->with('error', 'Keranjang Anda kosong.');
+        }
+
+        $data = $request->validate([
+            'contact_name' => ['required', 'string', 'max:255'],
+            'contact_email' => ['required', 'email', 'max:255'],
+            'contact_phone' => ['required', 'string', 'max:32'],
+            'address' => ['required', 'string', 'max:500'],
+            'province_code' => ['required', 'string', 'max:10'],
+            'province_name' => ['required', 'string', 'max:255'],
+            'regency_code' => ['required', 'string', 'max:10'],
+            'regency_name' => ['required', 'string', 'max:255'],
+            'district_code' => ['nullable', 'string', 'max:10'],
+            'district_name' => ['nullable', 'string', 'max:255'],
+            'village_code' => ['nullable', 'string', 'max:10'],
+            'village_name' => ['nullable', 'string', 'max:255'],
+            'postal_code' => ['required', 'string', 'max:10'],
+            'shipping_courier' => ['required', 'string', 'max:50'],
+            'shipping_service' => ['required', 'string', 'max:100'],
+            'shipping_cost' => ['required', 'numeric', 'min:0'],
+            'shipping_description' => ['nullable', 'string', 'max:255'],
+            'shipping_etd' => ['nullable', 'string', 'max:100'],
+        ]);
+
+        $gateway = $shipping->getActive();
+        if (! $gateway) {
+            return redirect()->route('checkout.payment')->with('error', 'Gateway pengiriman tidak tersedia.');
+        }
+
+        $config = $shipping->getGatewayConfig($gateway->key());
+        $destinationCode = $data['district_code'] ?: $data['regency_code'];
+        $destinationType = $data['district_code'] ? 'subdistrict' : 'city';
+
+        try {
+            $rates = $gateway->fetchRates($config, [
+                'destination' => [
+                    'code' => $destinationCode,
+                    'type' => $destinationType,
+                ],
+                'weight' => max(1, (int) ($cartSummary['total_weight_grams'] ?? 1)),
+            ]);
+        } catch (ShippingException $exception) {
+            return back()->withInput()->withErrors(['shipping_courier' => $exception->getMessage()]);
+        }
+
+        $selectedRate = collect($rates)->first(function ($rate) use ($data) {
+            return strtolower(Arr::get($rate, 'courier')) === strtolower($data['shipping_courier'])
+                && (string) Arr::get($rate, 'service') === (string) $data['shipping_service'];
+        });
+
+        if (! $selectedRate) {
+            return back()->withInput()->withErrors(['shipping_service' => 'Layanan pengiriman yang dipilih tidak tersedia.']);
+        }
+
+        $cost = (float) Arr::get($selectedRate, 'cost', $data['shipping_cost']);
+        $total = (float) $cartSummary['total_price'] + $cost;
+
+        ShippingSession::store([
+            'provider' => $gateway->key(),
+            'contact' => [
+                'name' => $data['contact_name'],
+                'email' => $data['contact_email'],
+                'phone' => $data['contact_phone'],
+            ],
+            'address' => [
+                'street' => $data['address'],
+                'province_code' => $data['province_code'],
+                'province_name' => $data['province_name'],
+                'regency_code' => $data['regency_code'],
+                'regency_name' => $data['regency_name'],
+                'district_code' => $data['district_code'],
+                'district_name' => $data['district_name'],
+                'village_code' => $data['village_code'],
+                'village_name' => $data['village_name'],
+                'postal_code' => $data['postal_code'],
+                'recipient' => $data['contact_name'],
+                'phone' => $data['contact_phone'],
+            ],
+            'selection' => [
+                'courier' => Arr::get($selectedRate, 'courier'),
+                'courier_name' => Arr::get($selectedRate, 'courier_name'),
+                'service' => Arr::get($selectedRate, 'service'),
+                'description' => Arr::get($selectedRate, 'description'),
+                'etd' => Arr::get($selectedRate, 'etd'),
+                'cost' => $cost,
+            ],
+            'cost' => $cost,
+            'total' => $total,
+            'metadata' => [
+                'requested_at' => now()->toIso8601String(),
+            ],
+        ]);
+
+        return redirect()->route('checkout.payment');
+    }
+
+    public function destroy(): RedirectResponse
+    {
+        ShippingSession::clear();
+
+        return redirect()->route('checkout.shipping');
+    }
+}

--- a/app/Models/Shipping.php
+++ b/app/Models/Shipping.php
@@ -13,16 +13,21 @@ class Shipping extends Model
 
     protected $fillable = [
         'order_id',
+        'provider',
         'courier',
+        'service',
         'tracking_number',
+        'external_id',
         'cost',
         'status',
         'estimated_delivery',
+        'metadata',
     ];
 
     protected $casts = [
         'cost' => 'float',
         'estimated_delivery' => 'date',
+        'metadata' => 'array',
     ];
 
     public function order(): BelongsTo

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Services\Payments\PaymentGatewayManager;
+use App\Services\Shipping\ShippingGatewayManager;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -14,6 +15,10 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->singleton(PaymentGatewayManager::class, function () {
             return new PaymentGatewayManager();
+        });
+
+        $this->app->singleton(ShippingGatewayManager::class, function () {
+            return new ShippingGatewayManager();
         });
     }
 

--- a/app/Services/Shipping/Exceptions/ShippingException.php
+++ b/app/Services/Shipping/Exceptions/ShippingException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Services\Shipping\Exceptions;
+
+use RuntimeException;
+
+class ShippingException extends RuntimeException
+{
+}

--- a/app/Services/Shipping/Gateways/RajaOngkirGateway.php
+++ b/app/Services/Shipping/Gateways/RajaOngkirGateway.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace App\Services\Shipping\Gateways;
+
+use App\Services\Shipping\Exceptions\ShippingException;
+use App\Services\Shipping\ShippingGateway;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+
+class RajaOngkirGateway implements ShippingGateway
+{
+    public function key(): string
+    {
+        return 'rajaongkir';
+    }
+
+    public function label(): string
+    {
+        return 'RajaOngkir';
+    }
+
+    public function description(): string
+    {
+        return 'Integrasi layanan pengiriman domestik menggunakan RajaOngkir.';
+    }
+
+    public function configFields(): array
+    {
+        return [
+            [
+                'key' => 'api_key',
+                'label' => 'API Key',
+                'type' => 'password',
+                'rules' => 'required|string',
+            ],
+            [
+                'key' => 'account_type',
+                'label' => 'Tipe Akun',
+                'type' => 'select',
+                'options' => [
+                    'starter' => 'Starter',
+                    'basic' => 'Basic',
+                    'pro' => 'Pro',
+                ],
+                'default' => 'starter',
+                'rules' => 'required|string|in:starter,basic,pro',
+            ],
+            [
+                'key' => 'origin_type',
+                'label' => 'Tipe Origin',
+                'type' => 'select',
+                'options' => [
+                    'city' => 'Kota/Kabupaten',
+                    'subdistrict' => 'Kecamatan',
+                ],
+                'default' => 'city',
+                'rules' => 'required|string|in:city,subdistrict',
+            ],
+            [
+                'key' => 'origin',
+                'label' => 'Kode Origin RajaOngkir',
+                'type' => 'text',
+                'placeholder' => 'Contoh: 501 (kode kota/kecamatan)',
+                'rules' => 'required|string',
+            ],
+            [
+                'key' => 'enabled_couriers',
+                'label' => 'Kurir Diaktifkan',
+                'type' => 'text',
+                'default' => 'jne,pos,tiki',
+                'help' => 'Pisahkan dengan koma, contoh: jne,pos,tiki,jnt',
+            ],
+        ];
+    }
+
+    public function fetchRates(array $config, array $payload): array
+    {
+        $apiKey = trim((string) ($config['api_key'] ?? ''));
+        $destination = Arr::get($payload, 'destination', []);
+        $destinationCode = (string) Arr::get($destination, 'code');
+        $destinationType = (string) Arr::get($destination, 'type', 'city');
+        $weight = (int) max(1, (int) ($payload['weight'] ?? 1));
+
+        if ($apiKey === '' || $destinationCode === '') {
+            return [];
+        }
+
+        $origin = (string) ($config['origin'] ?? '');
+        $originType = (string) ($config['origin_type'] ?? 'city');
+        $courier = $this->normalizeCouriers($config['enabled_couriers'] ?? 'jne,pos,tiki');
+
+        try {
+            $response = Http::withHeaders(['key' => $apiKey])
+                ->timeout(15)
+                ->post($this->baseUrl($config) . '/cost', [
+                    'origin' => $origin,
+                    'originType' => $originType,
+                    'destination' => $destinationCode,
+                    'destinationType' => $destinationType,
+                    'weight' => $weight,
+                    'courier' => $courier,
+                ]);
+        } catch (\Throwable $exception) {
+            throw new ShippingException($exception->getMessage(), (int) $exception->getCode());
+        }
+
+        if ($response->failed()) {
+            $message = Arr::get($response->json(), 'rajaongkir.status.description', 'Gagal mengambil tarif pengiriman.');
+            throw new ShippingException($message, $response->status());
+        }
+
+        $results = Arr::get($response->json(), 'rajaongkir.results', []);
+        $rates = [];
+
+        foreach ($results as $result) {
+            $code = strtoupper((string) Arr::get($result, 'code', ''));
+            $name = (string) Arr::get($result, 'name', $code);
+            $services = Arr::get($result, 'costs', []);
+
+            foreach ($services as $service) {
+                $serviceCode = (string) Arr::get($service, 'service', '');
+                $description = (string) Arr::get($service, 'description', '');
+                $costs = Arr::get($service, 'cost', []);
+
+                foreach ($costs as $cost) {
+                    $value = (float) Arr::get($cost, 'value', 0);
+                    $etd = Arr::get($cost, 'etd');
+                    $rates[] = [
+                        'provider' => $this->key(),
+                        'courier' => $code,
+                        'courier_name' => $name,
+                        'service' => $serviceCode,
+                        'description' => $description,
+                        'cost' => $value,
+                        'etd' => $etd,
+                        'note' => Arr::get($cost, 'note'),
+                    ];
+                }
+            }
+        }
+
+        return $rates;
+    }
+
+    public function createShipment(array $config, array $payload): array
+    {
+        return [
+            'status' => Arr::get($payload, 'status', 'packing'),
+            'message' => 'Permintaan pengiriman dicatat. Tambahkan nomor resi untuk melacak pengiriman.',
+        ];
+    }
+
+    public function cancelShipment(array $config, array $payload): array
+    {
+        return [
+            'status' => 'cancelled',
+            'message' => 'Pengiriman dibatalkan dari sistem toko.',
+        ];
+    }
+
+    public function trackShipment(array $config, array $context): array
+    {
+        $apiKey = trim((string) ($config['api_key'] ?? ''));
+        $trackingNumber = (string) Arr::get($context, 'tracking_number', Arr::get($context, 'awb'));
+        $courier = $this->extractTrackingCourier($context, $config);
+
+        if ($apiKey === '' || $trackingNumber === '' || $courier === '') {
+            throw new ShippingException('Data pelacakan tidak lengkap.');
+        }
+
+        try {
+            $response = Http::withHeaders(['key' => $apiKey])
+                ->timeout(15)
+                ->post($this->baseUrl($config) . '/waybill', [
+                    'waybill' => $trackingNumber,
+                    'courier' => $courier,
+                ]);
+        } catch (\Throwable $exception) {
+            throw new ShippingException($exception->getMessage(), (int) $exception->getCode());
+        }
+
+        if ($response->failed()) {
+            $message = Arr::get($response->json(), 'rajaongkir.status.description', 'Gagal melacak nomor resi.');
+            throw new ShippingException($message, $response->status());
+        }
+
+        $result = Arr::get($response->json(), 'rajaongkir.result', []);
+        $deliveryStatus = Arr::get($result, 'delivery_status.status', '');
+
+        return [
+            'status' => $this->normalizeStatus($deliveryStatus),
+            'summary' => Arr::get($result, 'summary', []),
+            'details' => Arr::get($result, 'details', []),
+            'delivery_status' => Arr::get($result, 'delivery_status', []),
+            'manifest' => Arr::get($result, 'manifest', []),
+        ];
+    }
+
+    protected function baseUrl(array $config): string
+    {
+        return match (strtolower((string) ($config['account_type'] ?? 'starter'))) {
+            'pro' => 'https://pro.rajaongkir.com/api',
+            'basic' => 'https://api.rajaongkir.com/basic',
+            default => 'https://api.rajaongkir.com/starter',
+        };
+    }
+
+    protected function normalizeCouriers(string $couriers): string
+    {
+        $normalized = strtolower(str_replace([';', ','], ':', $couriers));
+        $normalized = preg_replace('/[^a-z:]/', '', $normalized ?? '') ?? '';
+
+        return trim($normalized, ':') ?: 'jne:pos:tiki';
+    }
+
+    protected function extractTrackingCourier(array $context, array $config): string
+    {
+        $courier = strtolower((string) Arr::get($context, 'courier'));
+        if ($courier !== '') {
+            return $courier;
+        }
+
+        $couriers = explode(':', $this->normalizeCouriers($config['enabled_couriers'] ?? 'jne'));
+
+        return strtolower((string) Arr::first($couriers)) ?: 'jne';
+    }
+
+    protected function normalizeStatus(string $status): string
+    {
+        $status = strtolower($status);
+
+        return match (true) {
+            str_contains($status, 'deliver') => 'delivered',
+            str_contains($status, 'transit'), str_contains($status, 'process') => 'in_transit',
+            str_contains($status, 'cancel') => 'cancelled',
+            default => 'packing',
+        };
+    }
+}

--- a/app/Services/Shipping/ShippingGateway.php
+++ b/app/Services/Shipping/ShippingGateway.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services\Shipping;
+
+interface ShippingGateway
+{
+    public function key(): string;
+
+    public function label(): string;
+
+    public function description(): string;
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function configFields(): array;
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @param  array<string, mixed>  $payload
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchRates(array $config, array $payload): array;
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function createShipment(array $config, array $payload): array;
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function cancelShipment(array $config, array $payload): array;
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function trackShipment(array $config, array $context): array;
+}

--- a/app/Services/Shipping/ShippingGatewayManager.php
+++ b/app/Services/Shipping/ShippingGatewayManager.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Services\Shipping;
+
+use App\Models\Setting;
+use Illuminate\Support\Arr;
+
+class ShippingGatewayManager
+{
+    /**
+     * @var array<string, \App\Services\Shipping\ShippingGateway>
+     */
+    protected array $gateways = [];
+
+    public function __construct()
+    {
+        $configured = config('shipping.gateways', []);
+
+        foreach ($configured as $class) {
+            $instance = app($class);
+            if ($instance instanceof ShippingGateway) {
+                $this->gateways[$instance->key()] = $instance;
+            }
+        }
+    }
+
+    /**
+     * @return array<string, ShippingGateway>
+     */
+    public function all(): array
+    {
+        return $this->gateways;
+    }
+
+    public function get(?string $key = null): ?ShippingGateway
+    {
+        if (! $key) {
+            return null;
+        }
+
+        return $this->gateways[$key] ?? null;
+    }
+
+    public function getActiveKey(): ?string
+    {
+        $key = Setting::getValue('shipping.provider');
+
+        return $key ?: null;
+    }
+
+    public function getActive(): ?ShippingGateway
+    {
+        $key = $this->getActiveKey();
+
+        return $key ? $this->get($key) : null;
+    }
+
+    public function isEnabled(): bool
+    {
+        if (Setting::getValue('shipping.enabled', '0') !== '1') {
+            return false;
+        }
+
+        return $this->getActive() !== null;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function getAllGatewayConfigs(): array
+    {
+        $configs = [];
+        foreach ($this->gateways as $key => $gateway) {
+            $configs[$key] = $this->getGatewayConfig($key);
+        }
+
+        return $configs;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getGatewayConfig(string $gatewayKey): array
+    {
+        $gateway = $this->get($gatewayKey);
+        if (! $gateway) {
+            return [];
+        }
+
+        $config = [];
+        foreach ($gateway->configFields() as $field) {
+            $fieldKey = $field['key'];
+            $default = $field['default'] ?? null;
+            $value = Setting::getValue($this->configKey($gatewayKey, $fieldKey), $default);
+
+            if ($this->isBooleanField($field)) {
+                $config[$fieldKey] = $this->castBoolean($value, $default);
+            } else {
+                $config[$fieldKey] = $value;
+            }
+        }
+
+        return $config;
+    }
+
+    public function storeProvider(string $gatewayKey): void
+    {
+        Setting::updateOrCreate(
+            ['key' => 'shipping.provider'],
+            ['value' => $gatewayKey]
+        );
+    }
+
+    public function storeEnabled(bool $enabled): void
+    {
+        Setting::updateOrCreate(
+            ['key' => 'shipping.enabled'],
+            ['value' => $enabled ? '1' : '0']
+        );
+    }
+
+    public function storeConfig(string $gatewayKey, array $values): void
+    {
+        $gateway = $this->get($gatewayKey);
+        if (! $gateway) {
+            return;
+        }
+
+        foreach ($gateway->configFields() as $field) {
+            $fieldKey = $field['key'];
+            $value = Arr::get($values, $fieldKey, $field['default'] ?? null);
+
+            if ($this->isBooleanField($field)) {
+                $value = $value ? '1' : '0';
+            }
+
+            Setting::updateOrCreate(
+                ['key' => $this->configKey($gatewayKey, $fieldKey)],
+                ['value' => $value ?? '']
+            );
+        }
+    }
+
+    protected function configKey(string $gatewayKey, string $fieldKey): string
+    {
+        return "shipping.{$gatewayKey}.{$fieldKey}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $field
+     */
+    protected function isBooleanField(array $field): bool
+    {
+        $type = $field['type'] ?? 'text';
+
+        return in_array($type, ['toggle', 'boolean', 'checkbox'], true);
+    }
+
+    protected function castBoolean($value, $default = null): bool
+    {
+        if ($value === null) {
+            return (bool) $default;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        return in_array((string) $value, ['1', 'true', 'on'], true);
+    }
+}

--- a/app/Support/ShippingSession.php
+++ b/app/Support/ShippingSession.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Session;
+
+class ShippingSession
+{
+    public const SESSION_KEY = 'checkout.shipping';
+
+    public static function get(): array
+    {
+        $stored = Session::get(self::SESSION_KEY, []);
+
+        return is_array($stored) ? $stored : [];
+    }
+
+    public static function store(array $data): void
+    {
+        $payload = [
+            'contact' => Arr::get($data, 'contact', []),
+            'address' => Arr::get($data, 'address', []),
+            'selection' => Arr::get($data, 'selection', []),
+            'cost' => (float) Arr::get($data, 'cost', 0),
+            'total' => (float) Arr::get($data, 'total', 0),
+            'provider' => Arr::get($data, 'provider'),
+            'metadata' => Arr::get($data, 'metadata', []),
+        ];
+
+        Session::put(self::SESSION_KEY, $payload);
+    }
+
+    public static function clear(): void
+    {
+        Session::forget(self::SESSION_KEY);
+    }
+
+    public static function isReady(): bool
+    {
+        $data = self::get();
+
+        return ! empty($data['selection']) && ! empty($data['address']);
+    }
+}

--- a/config/shipping.php
+++ b/config/shipping.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'gateways' => [
+        \App\Services\Shipping\Gateways\RajaOngkirGateway::class,
+    ],
+];

--- a/database/migrations/2025_10_01_000000_update_shippings_table.php
+++ b/database/migrations/2025_10_01_000000_update_shippings_table.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('shippings', function (Blueprint $table) {
+            if (! Schema::hasColumn('shippings', 'provider')) {
+                $table->string('provider')->default('')->after('order_id');
+            }
+
+            if (! Schema::hasColumn('shippings', 'service')) {
+                $table->string('service')->nullable()->after('courier');
+            }
+
+            if (! Schema::hasColumn('shippings', 'external_id')) {
+                $table->string('external_id')->nullable()->after('tracking_number');
+            }
+
+            if (! Schema::hasColumn('shippings', 'metadata')) {
+                $table->json('metadata')->nullable()->after('estimated_delivery');
+            }
+        });
+
+        Schema::table('shippings', function (Blueprint $table) {
+            $table->string('status', 32)->default('pending')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('shippings', function (Blueprint $table) {
+            if (Schema::hasColumn('shippings', 'metadata')) {
+                $table->dropColumn('metadata');
+            }
+
+            if (Schema::hasColumn('shippings', 'external_id')) {
+                $table->dropColumn('external_id');
+            }
+
+            if (Schema::hasColumn('shippings', 'service')) {
+                $table->dropColumn('service');
+            }
+
+            if (Schema::hasColumn('shippings', 'provider')) {
+                $table->dropColumn('provider');
+            }
+        });
+
+        Schema::table('shippings', function (Blueprint $table) {
+            $table->string('status', 32)->default('packing')->change();
+        });
+    }
+};

--- a/resources/views/admin/orders/index.blade.php
+++ b/resources/views/admin/orders/index.blade.php
@@ -81,14 +81,87 @@
                       <td>
                         @if($shippingEnabled)
                           @php
-                            $shippingStatus = optional($order->shipping)->status ?? 'packing';
+                            $shippingData = $order->shipping;
+                            $shippingStatus = optional($shippingData)->status ?? 'packing';
                             $shippingLabel = [
                               'packing' => 'badge-info',
+                              'pending' => 'badge-info',
                               'in_transit' => 'badge-warning',
                               'delivered' => 'badge-success',
+                              'cancelled' => 'badge-danger',
                             ][$shippingStatus] ?? 'badge-secondary';
                           @endphp
-                          <span class="badge {{ $shippingLabel }} text-capitalize">{{ str_replace('_', ' ', $shippingStatus) }}</span>
+                          <div class="mb-2">
+                            <span class="badge {{ $shippingLabel }} text-capitalize">{{ str_replace('_', ' ', $shippingStatus) }}</span>
+                          </div>
+                          <div class="small text-muted">Kurir: {{ strtoupper($shippingData->courier ?? '-') }} {{ $shippingData?->service ? '(' . $shippingData->service . ')' : '' }}</div>
+                          <div class="small text-muted">Nomor Resi: {{ $shippingData?->tracking_number ?? 'Belum diatur' }}</div>
+                          <div class="small text-muted">ID Eksternal: {{ $shippingData?->external_id ?? 'Tidak ada' }}</div>
+                          <div class="small text-muted">Ongkir: Rp {{ number_format($shippingData?->cost ?? 0, 0, ',', '.') }}</div>
+                          @php
+                            $activeOrderOld = (int) old('order_id', 0) === $order->id;
+                          @endphp
+                          <details class="mt-2">
+                            <summary class="small font-weight-semibold text-primary" style="cursor: pointer;">Kelola Pengiriman</summary>
+                            <div class="mt-2 p-2 bg-light rounded">
+                              <form method="POST" action="{{ route('admin.orders.shipping.update', $order) }}">
+                                @csrf
+                                @method('PATCH')
+                                <input type="hidden" name="order_id" value="{{ $order->id }}">
+                                <div class="form-group mb-2">
+                                  <label class="small text-muted mb-1" for="tracking_number_{{ $order->id }}">Nomor Resi</label>
+                                  <input type="text" class="form-control form-control-sm" id="tracking_number_{{ $order->id }}" name="tracking_number" value="{{ $activeOrderOld ? old('tracking_number') : $shippingData?->tracking_number }}" placeholder="Masukkan nomor resi">
+                                </div>
+                                <div class="form-group mb-2">
+                                  <label class="small text-muted mb-1" for="external_id_{{ $order->id }}">ID Eksternal</label>
+                                  <input type="text" class="form-control form-control-sm" id="external_id_{{ $order->id }}" name="external_id" value="{{ $activeOrderOld ? old('external_id') : $shippingData?->external_id }}" placeholder="ID dari gateway (opsional)">
+                                </div>
+                                <div class="form-group mb-2">
+                                  <label class="small text-muted mb-1" for="courier_{{ $order->id }}">Kurir</label>
+                                  <input type="text" class="form-control form-control-sm" id="courier_{{ $order->id }}" name="courier" value="{{ $activeOrderOld ? old('courier') : $shippingData?->courier }}" placeholder="Kode kurir">
+                                </div>
+                                <div class="form-group mb-2">
+                                  <label class="small text-muted mb-1" for="service_{{ $order->id }}">Layanan</label>
+                                  <input type="text" class="form-control form-control-sm" id="service_{{ $order->id }}" name="service" value="{{ $activeOrderOld ? old('service') : $shippingData?->service }}" placeholder="Nama layanan">
+                                </div>
+                                <div class="form-group mb-2">
+                                  <label class="small text-muted mb-1" for="status_{{ $order->id }}">Status</label>
+                                  <select id="status_{{ $order->id }}" class="form-control form-control-sm" name="status">
+                                    <option value="">-- Pilih status --</option>
+                                    @foreach(['pending' => 'Menunggu', 'packing' => 'Sedang diproses', 'in_transit' => 'Sedang dikirim', 'delivered' => 'Terkirim', 'cancelled' => 'Dibatalkan'] as $value => $label)
+                                      <option value="{{ $value }}" {{ ($activeOrderOld ? old('status') : $shippingStatus) === $value ? 'selected' : '' }}>{{ $label }}</option>
+                                    @endforeach
+                                  </select>
+                                </div>
+                                <div class="form-group mb-2">
+                                  <label class="small text-muted mb-1" for="cost_{{ $order->id }}">Biaya Kirim</label>
+                                  <input type="number" class="form-control form-control-sm" id="cost_{{ $order->id }}" name="cost" value="{{ $activeOrderOld ? old('cost') : $shippingData?->cost }}" min="0" step="0.01">
+                                </div>
+                                <div class="form-group mb-3">
+                                  <label class="small text-muted mb-1" for="estimated_delivery_{{ $order->id }}">Estimasi Tiba</label>
+                                  <input type="date" class="form-control form-control-sm" id="estimated_delivery_{{ $order->id }}" name="estimated_delivery" value="{{ $activeOrderOld ? old('estimated_delivery') : optional($shippingData?->estimated_delivery)->format('Y-m-d') }}">
+                                </div>
+                                <button type="submit" class="btn btn-sm btn-primary btn-block">Simpan Perubahan</button>
+                              </form>
+
+                              <div class="d-flex flex-wrap mt-3" style="gap: .5rem;">
+                                <form method="POST" action="{{ route('admin.orders.shipping.create', $order) }}">
+                                  @csrf
+                                  <button type="submit" class="btn btn-sm btn-outline-primary">Buat Pengiriman</button>
+                                </form>
+                                <form method="POST" action="{{ route('admin.orders.shipping.track', $order) }}">
+                                  @csrf
+                                  <input type="hidden" name="tracking_number" value="{{ $shippingData?->tracking_number }}">
+                                  <input type="hidden" name="courier" value="{{ $shippingData?->courier }}">
+                                  <button type="submit" class="btn btn-sm btn-outline-info" {{ empty($shippingData?->tracking_number) ? 'disabled' : '' }}>Lacak</button>
+                                </form>
+                                <form method="POST" action="{{ route('admin.orders.shipping.cancel', $order) }}">
+                                  @csrf
+                                  <button type="submit" class="btn btn-sm btn-outline-danger">Batalkan</button>
+                                </form>
+                              </div>
+                            </div>
+                          </details>
                         @else
                           <form method="POST" action="{{ route('admin.orders.review', $order) }}">
                             @csrf

--- a/resources/views/admin/shipping/index.blade.php
+++ b/resources/views/admin/shipping/index.blade.php
@@ -1,0 +1,171 @@
+@extends('layout.admin')
+
+@section('content')
+  <div class="main-panel">
+    <div class="content-wrapper">
+      <div class="row">
+        <div class="col-12 grid-margin stretch-card">
+          <div class="card">
+            <div class="card-body">
+              <h4 class="card-title">Pengaturan Pengiriman</h4>
+              <p class="card-description mb-4">Aktifkan layanan pengiriman toko, pilih gateway yang tersedia, dan simpan kredensial yang dibutuhkan untuk menghitung ongkos kirim.</p>
+
+              @if(session('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+              @endif
+
+              @if($errors->any())
+                <div class="alert alert-danger">
+                  <ul class="mb-0">
+                    @foreach($errors->all() as $error)
+                      <li>{{ $error }}</li>
+                    @endforeach
+                  </ul>
+                </div>
+              @endif
+
+              <form method="POST" action="{{ route('admin.shipping.update') }}" id="shipping-settings-form">
+                @csrf
+
+                <div class="form-group">
+                  <div class="form-check form-check-flat form-check-primary">
+                    <label class="form-check-label" for="shipping-enabled">
+                      <input type="checkbox" class="form-check-input" id="shipping-enabled" name="enabled" value="1" {{ old('enabled', $enabled ? 1 : 0) ? 'checked' : '' }}>
+                      Aktifkan Pengiriman
+                      <i class="input-helper"></i>
+                    </label>
+                  </div>
+                  <small class="form-text text-muted">Saat dinonaktifkan, pelanggan akan langsung diarahkan ke halaman pembayaran tanpa langkah pengiriman.</small>
+                </div>
+
+                <div class="form-group">
+                  <label for="shipping-provider">Penyedia Pengiriman</label>
+                  <select id="shipping-provider" name="provider" class="form-control">
+                    <option value="">-- Pilih Gateway --</option>
+                    @foreach($gateways as $key => $gateway)
+                      <option value="{{ $key }}" {{ old('provider', $activeKey) === $key ? 'selected' : '' }}>{{ $gateway->label() }}</option>
+                    @endforeach
+                  </select>
+                  <small class="form-text text-muted">Pilih gateway yang ingin diintegrasikan. Untuk saat ini hanya RajaOngkir yang tersedia.</small>
+                </div>
+
+                @foreach($gateways as $key => $gateway)
+                  @php
+                    $sectionConfig = $configs[$key] ?? [];
+                  @endphp
+                  <div class="shipping-gateway-section" data-shipping-gateway="{{ $key }}" style="display:none;">
+                    <div class="mb-4">
+                      <h5 class="font-weight-semibold mb-1">{{ $gateway->label() }}</h5>
+                      <p class="text-muted mb-0">{{ $gateway->description() }}</p>
+                    </div>
+
+                    <div class="row">
+                      @foreach($gateway->configFields() as $field)
+                        @php
+                          $fieldName = 'config[' . $field['key'] . ']';
+                          $inputId = $key . '_' . $field['key'];
+                          $value = old('provider') === $key
+                            ? old('config.' . $field['key'], $sectionConfig[$field['key']] ?? ($field['default'] ?? null))
+                            : ($sectionConfig[$field['key']] ?? ($field['default'] ?? null));
+                        @endphp
+                        <div class="col-md-6">
+                          <div class="form-group">
+                            <label for="{{ $inputId }}">{{ $field['label'] }}</label>
+                            @switch($field['type'] ?? 'text')
+                              @case('select')
+                                <select name="{{ $fieldName }}" id="{{ $inputId }}" class="form-control">
+                                  @foreach($field['options'] ?? [] as $optionValue => $optionLabel)
+                                    <option value="{{ $optionValue }}" {{ (string) $value === (string) $optionValue ? 'selected' : '' }}>{{ $optionLabel }}</option>
+                                  @endforeach
+                                </select>
+                                @break
+
+                              @case('toggle')
+                              @case('checkbox')
+                              @case('boolean')
+                                <div class="form-check form-switch">
+                                  <input type="hidden" name="{{ $fieldName }}" value="0">
+                                  <input type="checkbox" class="form-check-input" id="{{ $inputId }}" name="{{ $fieldName }}" value="1" {{ $value ? 'checked' : '' }}>
+                                </div>
+                                @break
+
+                              @case('password')
+                                <input type="password" class="form-control" id="{{ $inputId }}" name="{{ $fieldName }}" value="{{ $value }}" autocomplete="new-password">
+                                @break
+
+                              @default
+                                <input type="{{ $field['type'] ?? 'text' }}" class="form-control" id="{{ $inputId }}" name="{{ $fieldName }}" value="{{ $value }}">
+                            @endswitch
+                            @if(!empty($field['help']))
+                              <small class="form-text text-muted">{{ $field['help'] }}</small>
+                            @endif
+                            @if($field['key'] === 'origin')
+                              <small class="form-text text-muted">Gunakan kode kota/kecamatan dari RajaOngkir sesuai dengan tipe origin yang dipilih.</small>
+                            @endif
+                          </div>
+                        </div>
+                      @endforeach
+                    </div>
+
+                    <div class="alert alert-light border mt-3" role="alert">
+                      <h6 class="font-weight-semibold mb-2">Tips menentukan origin RajaOngkir</h6>
+                      <p class="mb-2">Kode origin mengikuti data resmi RajaOngkir. Anda dapat menggunakan endpoint wilayah yang disediakan Laravel Nusa pada halaman pengiriman pelanggan untuk mengetahui kode kota/kecamatan terlebih dahulu.</p>
+                      <small class="text-muted d-block">Contoh endpoint: <code>/nusa/provinces</code>, <code>/nusa/provinces/{kode}/regencies</code>, <code>/nusa/regencies/{kode}/districts</code>.</small>
+                    </div>
+                  </div>
+                @endforeach
+
+                <div class="mt-4">
+                  <button type="submit" class="btn btn-primary">Simpan Pengaturan</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection
+
+@section('script')
+  <script>
+    (function() {
+      const enabledToggle = document.getElementById('shipping-enabled');
+      const providerSelect = document.getElementById('shipping-provider');
+      const sections = document.querySelectorAll('[data-shipping-gateway]');
+
+      function toggleSections(providerKey, enabled) {
+        sections.forEach(section => {
+          const isActive = enabled && section.getAttribute('data-shipping-gateway') === providerKey;
+          section.style.display = isActive ? 'block' : 'none';
+          const inputs = section.querySelectorAll('input, select, textarea');
+          inputs.forEach(input => {
+            if (isActive) {
+              input.removeAttribute('disabled');
+            } else {
+              input.setAttribute('disabled', 'disabled');
+            }
+          });
+        });
+        if (providerSelect) {
+          providerSelect.disabled = !enabled;
+        }
+      }
+
+      function refresh() {
+        const enabled = enabledToggle ? enabledToggle.checked : false;
+        const providerKey = providerSelect ? providerSelect.value : '';
+        toggleSections(providerKey, enabled && !!providerKey);
+      }
+
+      if (enabledToggle) {
+        enabledToggle.addEventListener('change', refresh);
+      }
+      if (providerSelect) {
+        providerSelect.addEventListener('change', refresh);
+      }
+
+      refresh();
+    })();
+  </script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,8 @@ use App\Http\Controllers\CheckoutController;
 use App\Http\Controllers\OrderController;
 use App\Http\Controllers\Admin\OrderController as AdminOrderController;
 use App\Http\Controllers\ArticleController as FrontArticleController;
+use App\Http\Controllers\ShippingController;
+use App\Http\Controllers\Admin\ShippingController as AdminShippingController;
 
 /*
 |--------------------------------------------------------------------------
@@ -90,6 +92,10 @@ Route::get('/pesanan', [OrderController::class, 'index'])->name('orders.index');
 Route::get('/checkout/payment', [CheckoutController::class, 'payment'])->name('checkout.payment');
 Route::post('/checkout/payment/session', [CheckoutController::class, 'createPaymentSession'])->name('checkout.payment.session');
 Route::post('/checkout/payment/webhook/{gateway}', [CheckoutController::class, 'webhook'])->name('checkout.payment.webhook');
+Route::get('/checkout/shipping', [ShippingController::class, 'index'])->name('checkout.shipping');
+Route::post('/checkout/shipping', [ShippingController::class, 'store'])->name('checkout.shipping.store');
+Route::post('/checkout/shipping/rates', [ShippingController::class, 'rates'])->name('checkout.shipping.rates');
+Route::delete('/checkout/shipping', [ShippingController::class, 'destroy'])->name('checkout.shipping.destroy');
 
 Route::get('themes/{theme}/assets/{path}', ThemeAssetController::class)
     ->where('path', '.*')
@@ -143,6 +149,10 @@ Route::prefix('admin')->middleware(['auth'])->group(function () {
     ]))->group(function () {
         Route::get('order', [AdminOrderController::class, 'index'])->name('admin.orders.index');
         Route::patch('order/{order}/review', [AdminOrderController::class, 'toggleReview'])->name('admin.orders.review');
+        Route::patch('order/{order}/shipping', [AdminOrderController::class, 'updateShipping'])->name('admin.orders.shipping.update');
+        Route::post('order/{order}/shipping/track', [AdminOrderController::class, 'trackShipping'])->name('admin.orders.shipping.track');
+        Route::post('order/{order}/shipping/cancel', [AdminOrderController::class, 'cancelShipping'])->name('admin.orders.shipping.cancel');
+        Route::post('order/{order}/shipping/create', [AdminOrderController::class, 'createShipping'])->name('admin.orders.shipping.create');
     });
 
     Route::middleware('role:' . User::ROLE_ADMINISTRATOR)->group(function () {
@@ -177,6 +187,9 @@ Route::prefix('admin')->middleware(['auth'])->group(function () {
 
         Route::get('payments', [PaymentController::class, 'index'])->name('admin.payments.index');
         Route::post('payments', [PaymentController::class, 'update'])->name('admin.payments.update');
+
+        Route::get('shipping', [AdminShippingController::class, 'index'])->name('admin.shipping.index');
+        Route::post('shipping', [AdminShippingController::class, 'update'])->name('admin.shipping.update');
 
         Route::resource('users', \App\Http\Controllers\Admin\UserController::class)->except(['show'])->names('admin.users');
     });

--- a/themes/theme-herbalgreen/views/order.blade.php
+++ b/themes/theme-herbalgreen/views/order.blade.php
@@ -231,6 +231,12 @@
                 <div class="order-summary">
                     <div class="order-meta">Total Produk: {{ $order->items->sum('quantity') }}</div>
                     <div class="order-meta">Total Pembayaran: <strong>Rp {{ number_format($order->total_price ?? 0, 0, ',', '.') }}</strong></div>
+                    @if($shippingEnabled)
+                        <div class="order-meta">Kurir: {{ strtoupper($order->shipping->courier ?? 'Belum ditentukan') }} {{ $order->shipping->service ? '('.$order->shipping->service.')' : '' }}</div>
+                        <div class="order-meta">Ongkir: Rp {{ number_format($order->shipping->cost ?? 0, 0, ',', '.') }}</div>
+                        <div class="order-meta">Nomor Resi: {{ $order->shipping->tracking_number ?? 'Belum tersedia' }}</div>
+                        <div class="order-meta">Status Pengiriman: {{ ucfirst(str_replace('_', ' ', $order->shipping->status ?? 'pending')) }}</div>
+                    @endif
                 </div>
             </div>
         @endforeach

--- a/themes/theme-herbalgreen/views/payment.blade.php
+++ b/themes/theme-herbalgreen/views/payment.blade.php
@@ -198,10 +198,21 @@
                         <span>Rp {{ $item['subtotal_formatted'] }}</span>
                     </div>
                 @endforeach
+                @if($shippingEnabled)
+                    <div class="summary-item">
+                        <div>
+                            <h4>Ongkos Kirim</h4>
+                            @if(!empty($shippingData['selection']))
+                                <small>{{ strtoupper($shippingData['selection']['courier'] ?? '') }} • {{ $shippingData['selection']['service'] ?? '' }}</small>
+                            @endif
+                        </div>
+                        <span>Rp {{ $cartSummary['shipping_cost_formatted'] ?? '0' }}</span>
+                    </div>
+                @endif
             </div>
             <div class="summary-total">
                 <span>Total Pembayaran</span>
-                <span>Rp {{ $cartSummary['total_price_formatted'] ?? '0' }}</span>
+                <span>Rp {{ $cartSummary['grand_total_formatted'] ?? ($cartSummary['total_price_formatted'] ?? '0') }}</span>
             </div>
         </div>
         <div class="card-box">
@@ -238,6 +249,12 @@
                 @endif
                 @if(!empty($publicConfig['va']))
                     <div>Virtual Account: {{ $publicConfig['va'] }}</div>
+                @endif
+                @if($shippingEnabled && !empty($shippingData['selection']))
+                    <div class="mt-2"><strong>Pengiriman:</strong> {{ strtoupper($shippingData['selection']['courier'] ?? '') }} - {{ $shippingData['selection']['service'] ?? '' }} (Rp {{ $cartSummary['shipping_cost_formatted'] ?? '0' }})</div>
+                    @if(!empty($shippingData['address']['street']))
+                        <div class="small">Alamat: {{ $shippingData['address']['street'] }}</div>
+                    @endif
                 @endif
             </div>
             <button class="cta-button" data-pay-button>Bayar dengan {{ $gatewayLabel }}</button>

--- a/themes/theme-herbalgreen/views/shipping-script.blade.php
+++ b/themes/theme-herbalgreen/views/shipping-script.blade.php
@@ -1,0 +1,331 @@
+<script>
+(function(){
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    const provincesEndpoint = '{{ url('/nusa/provinces') }}';
+    const regencyEndpoint = '{{ url('/nusa/provinces') }}/';
+    const districtEndpoint = '{{ url('/nusa/regencies') }}/';
+    const villageEndpoint = '{{ url('/nusa/districts') }}/';
+    const villageShowEndpoint = '{{ url('/nusa/villages') }}/';
+    const ratesEndpoint = '{{ route('checkout.shipping.rates') }}';
+
+    const provinceSelect = document.getElementById('province');
+    const regencySelect = document.getElementById('regency');
+    const districtSelect = document.getElementById('district');
+    const villageSelect = document.getElementById('village');
+    const postalInput = document.getElementById('postal_code');
+    const methodsContainer = document.getElementById('shipping-methods');
+    const shippingCostInput = document.getElementById('shipping_cost');
+    const shippingCourierInput = document.getElementById('shipping_courier');
+    const shippingServiceInput = document.getElementById('shipping_service');
+    const shippingEtdInput = document.getElementById('shipping_etd');
+    const provinceNameInput = document.getElementById('province_name');
+    const regencyNameInput = document.getElementById('regency_name');
+    const districtNameInput = document.getElementById('district_name');
+    const villageNameInput = document.getElementById('village_name');
+    const feedback = document.getElementById('shipping-feedback');
+    const shippingCostDisplay = document.getElementById('shipping-cost-display');
+    const grandTotalDisplay = document.getElementById('grand-total-display');
+    const subtotal = {{ (float) $cartSummary['total_price'] }};
+
+    const state = {
+        province: '{{ old('province_code', $address['province_code'] ?? '') }}',
+        regency: '{{ old('regency_code', $address['regency_code'] ?? '') }}',
+        district: '{{ old('district_code', $address['district_code'] ?? '') }}',
+        village: '{{ old('village_code', $address['village_code'] ?? '') }}',
+        courier: '{{ $selectedCourier }}',
+        service: '{{ $selectedService }}'
+    };
+
+    function setSelectOptions(select, items, selectedValue) {
+        if (!select) return;
+        const current = select.value;
+        select.innerHTML = '<option value="">Pilih</option>';
+        items.forEach(item => {
+            const option = document.createElement('option');
+            option.value = item.code;
+            option.textContent = item.name;
+            if (selectedValue && selectedValue === item.code) {
+                option.selected = true;
+            }
+            select.appendChild(option);
+        });
+        if (selectedValue) {
+            select.value = selectedValue;
+        } else if (current) {
+            select.value = current;
+        }
+    }
+
+    function fetchJSON(url) {
+        return fetch(url, { headers: { 'Accept': 'application/json' } })
+            .then(response => {
+                if (!response.ok) throw new Error('Gagal memuat data');
+                return response.json();
+            });
+    }
+
+    function updateHiddenNames() {
+        const provinceText = provinceSelect.options[provinceSelect.selectedIndex]?.textContent || '';
+        const regencyText = regencySelect.options[regencySelect.selectedIndex]?.textContent || '';
+        const districtText = districtSelect.options[districtSelect.selectedIndex]?.textContent || '';
+        const villageText = villageSelect.options[villageSelect.selectedIndex]?.textContent || '';
+        if (provinceNameInput) provinceNameInput.value = provinceText;
+        if (regencyNameInput) regencyNameInput.value = regencyText;
+        if (districtNameInput) districtNameInput.value = districtText;
+        if (villageNameInput) villageNameInput.value = villageText;
+    }
+
+    function showFeedback(message, type = 'info') {
+        if (!feedback) return;
+        feedback.textContent = message;
+        feedback.className = 'alert alert-' + (type === 'error' ? 'error' : 'info');
+        feedback.style.display = message ? 'block' : 'none';
+    }
+
+    function renderRates(rates) {
+        if (!methodsContainer) return;
+        methodsContainer.innerHTML = '';
+        if (!rates.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty-state';
+            empty.textContent = 'Layanan pengiriman belum tersedia untuk alamat ini.';
+            methodsContainer.appendChild(empty);
+            return;
+        }
+
+        rates.forEach(rate => {
+            const wrapper = document.createElement('label');
+            wrapper.className = 'shipping-method';
+            if (rate.courier === state.courier && rate.service === state.service) {
+                wrapper.classList.add('active');
+            }
+
+            const left = document.createElement('div');
+            const title = document.createElement('div');
+            title.style.fontWeight = '600';
+            title.textContent = (rate.courier_name || rate.courier).toUpperCase() + ' - ' + rate.service;
+            const desc = document.createElement('div');
+            desc.style.fontSize = '0.9rem';
+            desc.style.color = '#4f6f58';
+            desc.textContent = rate.description || 'Pengiriman reguler';
+            left.appendChild(title);
+            left.appendChild(desc);
+
+            const right = document.createElement('div');
+            right.style.textAlign = 'right';
+            right.innerHTML = '<strong>Rp ' + new Intl.NumberFormat('id-ID').format(rate.cost) + '</strong>' +
+                (rate.etd ? '<div class="small">ETD: ' + rate.etd + '</div>' : '');
+
+            const radio = document.createElement('input');
+            radio.type = 'radio';
+            radio.name = 'shipping_option';
+            radio.value = rate.courier + '|' + rate.service;
+            radio.checked = rate.courier === state.courier && rate.service === state.service;
+
+            radio.addEventListener('change', function(){
+                state.courier = rate.courier;
+                state.service = rate.service;
+                shippingCourierInput.value = rate.courier;
+                shippingServiceInput.value = rate.service;
+                shippingCostInput.value = rate.cost;
+                shippingEtdInput.value = rate.etd || '';
+                if (shippingCostDisplay) {
+                    shippingCostDisplay.textContent = 'Rp ' + new Intl.NumberFormat('id-ID').format(rate.cost);
+                }
+                if (grandTotalDisplay) {
+                    grandTotalDisplay.textContent = 'Rp ' + new Intl.NumberFormat('id-ID').format(subtotal + rate.cost);
+                }
+                methodsContainer.querySelectorAll('.shipping-method').forEach(el => el.classList.remove('active'));
+                wrapper.classList.add('active');
+            });
+
+            wrapper.appendChild(radio);
+            wrapper.appendChild(left);
+            wrapper.appendChild(right);
+            methodsContainer.appendChild(wrapper);
+        });
+
+        const selected = rates.find(rate => rate.courier === state.courier && rate.service === state.service) || rates[0];
+        if (selected) {
+            state.courier = selected.courier;
+            state.service = selected.service;
+            shippingCourierInput.value = selected.courier;
+            shippingServiceInput.value = selected.service;
+            shippingCostInput.value = selected.cost;
+            shippingEtdInput.value = selected.etd || '';
+            if (shippingCostDisplay) {
+                shippingCostDisplay.textContent = 'Rp ' + new Intl.NumberFormat('id-ID').format(selected.cost);
+            }
+            if (grandTotalDisplay) {
+                grandTotalDisplay.textContent = 'Rp ' + new Intl.NumberFormat('id-ID').format(subtotal + selected.cost);
+            }
+            methodsContainer.querySelectorAll('.shipping-method').forEach(el => {
+                if (el.querySelector('input')?.value === selected.courier + '|' + selected.service) {
+                    el.classList.add('active');
+                    el.querySelector('input').checked = true;
+                }
+            });
+        }
+    }
+
+    function fetchRatesIfReady() {
+        if (!provinceSelect.value || !regencySelect.value) {
+            return;
+        }
+        const payload = {
+            province_code: provinceSelect.value,
+            regency_code: regencySelect.value,
+            district_code: districtSelect.value,
+            postal_code: postalInput.value
+        };
+
+        fetch(ratesEndpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'X-CSRF-TOKEN': csrfToken,
+            },
+            body: JSON.stringify(payload)
+        })
+        .then(res => {
+            if (!res.ok) throw res;
+            return res.json();
+        })
+        .then(data => {
+            showFeedback('');
+            renderRates(data.rates || []);
+        })
+        .catch(async error => {
+            let message = 'Gagal memuat ongkir.';
+            if (error.json) {
+                const body = await error.json();
+                message = body.message || message;
+            }
+            showFeedback(message, 'error');
+            renderRates([]);
+        });
+    }
+
+    function initRegency(provinceCode, selected) {
+        if (!provinceCode) {
+            setSelectOptions(regencySelect, [], '');
+            setSelectOptions(districtSelect, [], '');
+            setSelectOptions(villageSelect, [], '');
+            return;
+        }
+        fetchJSON(regencyEndpoint + provinceCode + '/regencies')
+            .then(response => {
+                const items = response.data || response;
+                setSelectOptions(regencySelect, items, selected);
+                updateHiddenNames();
+                if (selected) {
+                    initDistrict(selected, state.district);
+                } else {
+                    setSelectOptions(districtSelect, [], '');
+                    setSelectOptions(villageSelect, [], '');
+                }
+            });
+    }
+
+    function initDistrict(regencyCode, selected) {
+        if (!regencyCode) {
+            setSelectOptions(districtSelect, [], '');
+            setSelectOptions(villageSelect, [], '');
+            return;
+        }
+        fetchJSON(districtEndpoint + regencyCode + '/districts')
+            .then(response => {
+                const items = response.data || response;
+                setSelectOptions(districtSelect, items, selected);
+                updateHiddenNames();
+                if (selected) {
+                    initVillage(selected, state.village);
+                } else {
+                    setSelectOptions(villageSelect, [], '');
+                }
+            });
+    }
+
+    function initVillage(districtCode, selected) {
+        if (!districtCode) {
+            setSelectOptions(villageSelect, [], '');
+            return;
+        }
+        fetchJSON(villageEndpoint + districtCode + '/villages')
+            .then(response => {
+                const items = response.data || response;
+                setSelectOptions(villageSelect, items, selected);
+                updateHiddenNames();
+                if (selected) {
+                    fetchVillage(selected);
+                }
+            });
+    }
+
+    function fetchVillage(code) {
+        if (!code) return;
+        fetchJSON(villageShowEndpoint + code)
+            .then(response => {
+                const village = response.data || response;
+                if (postalInput && village.postal_code) {
+                    postalInput.value = village.postal_code;
+                }
+                updateHiddenNames();
+                fetchRatesIfReady();
+            });
+    }
+
+    if (provinceSelect) {
+        provinceSelect.addEventListener('change', function(){
+            state.province = this.value;
+            provinceNameInput.value = this.options[this.selectedIndex]?.textContent || '';
+            initRegency(this.value, '');
+            fetchRatesIfReady();
+        });
+    }
+    if (regencySelect) {
+        regencySelect.addEventListener('change', function(){
+            state.regency = this.value;
+            regencyNameInput.value = this.options[this.selectedIndex]?.textContent || '';
+            initDistrict(this.value, '');
+            fetchRatesIfReady();
+        });
+    }
+    if (districtSelect) {
+        districtSelect.addEventListener('change', function(){
+            state.district = this.value;
+            districtNameInput.value = this.options[this.selectedIndex]?.textContent || '';
+            initVillage(this.value, '');
+            fetchRatesIfReady();
+        });
+    }
+    if (villageSelect) {
+        villageSelect.addEventListener('change', function(){
+            state.village = this.value;
+            villageNameInput.value = this.options[this.selectedIndex]?.textContent || '';
+            fetchVillage(this.value);
+        });
+    }
+    if (postalInput) {
+        postalInput.addEventListener('input', function(){
+            fetchRatesIfReady();
+        });
+    }
+
+    if (state.province) {
+        initRegency(state.province, state.regency);
+    }
+    if (state.regency && state.district) {
+        initDistrict(state.regency, state.district);
+    }
+    if (state.district && state.village) {
+        initVillage(state.district, state.village);
+    }
+    if (!state.province) {
+        updateHiddenNames();
+    } else {
+        fetchRatesIfReady();
+    }
+})();
+</script>

--- a/themes/theme-herbalgreen/views/shipping/rajaongkir.blade.php
+++ b/themes/theme-herbalgreen/views/shipping/rajaongkir.blade.php
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>Pengiriman</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+    <style>
+        #shipping-page {
+            padding: 3rem 2rem;
+            background: #f5fbf5;
+        }
+        .shipping-layout {
+            display: grid;
+            grid-template-columns: minmax(0, 2fr) minmax(0, 1.25fr);
+            gap: 2rem;
+            max-width: 1100px;
+            margin: 0 auto;
+        }
+        .shipping-card {
+            background: #fff;
+            border-radius: 18px;
+            box-shadow: 0 12px 30px rgba(0,0,0,0.08);
+            padding: 2rem;
+        }
+        .shipping-card h2 {
+            margin-top: 0;
+            margin-bottom: 1.5rem;
+            font-size: 1.4rem;
+            color: var(--color-primary);
+        }
+        .form-grid {
+            display: grid;
+            gap: 1.25rem;
+        }
+        .form-row {
+            display: flex;
+            gap: 1rem;
+        }
+        .form-row .form-field {
+            flex: 1;
+        }
+        label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: .5rem;
+            color: #1f3c2f;
+        }
+        input, select, textarea {
+            width: 100%;
+            padding: 0.85rem 1rem;
+            border-radius: 12px;
+            border: 1px solid #d9e6de;
+            background: #fdfdfd;
+            font-size: 0.95rem;
+        }
+        textarea {
+            min-height: 110px;
+            resize: vertical;
+        }
+        .shipping-methods {
+            margin-top: 1.5rem;
+            display: grid;
+            gap: 1rem;
+        }
+        .shipping-method {
+            border: 1px solid #dcefe2;
+            border-radius: 14px;
+            padding: 1rem 1.25rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            cursor: pointer;
+            transition: border-color .2s ease, box-shadow .2s ease;
+        }
+        .shipping-method.active {
+            border-color: var(--color-primary);
+            box-shadow: 0 8px 24px rgba(67,160,71,0.18);
+        }
+        .shipping-method input {
+            margin-right: 1rem;
+        }
+        .shipping-summary {
+            display: grid;
+            gap: 1rem;
+        }
+        .summary-items {
+            border: 1px solid #e4efe7;
+            border-radius: 16px;
+            padding: 1.5rem;
+        }
+        .summary-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: .75rem;
+        }
+        .summary-row:last-child {
+            margin-bottom: 0;
+        }
+        .summary-row strong {
+            color: #1f3c2f;
+        }
+        .total-row {
+            border-top: 1px dashed #cbe2d1;
+            padding-top: 1rem;
+            margin-top: 1rem;
+            font-size: 1.2rem;
+            font-weight: 700;
+            color: var(--color-primary);
+        }
+        .checkout-button {
+            width: 100%;
+            border: none;
+            border-radius: 999px;
+            padding: 1rem 1.5rem;
+            background: var(--color-primary);
+            color: #fff;
+            font-weight: 600;
+            margin-top: 1.5rem;
+            cursor: pointer;
+            transition: transform .2s ease;
+        }
+        .checkout-button:hover {
+            transform: translateY(-1px);
+        }
+        .alert {
+            padding: .8rem 1rem;
+            border-radius: 12px;
+            margin-bottom: 1rem;
+            font-weight: 600;
+        }
+        .alert-error {
+            background: rgba(220,53,69,0.12);
+            color: #a31d2a;
+            border: 1px solid rgba(220,53,69,0.2);
+        }
+        .alert-info {
+            background: rgba(33,150,243,0.12);
+            color: #0d47a1;
+            border: 1px solid rgba(33,150,243,0.24);
+        }
+        .empty-state {
+            padding: 2rem;
+            border-radius: 14px;
+            background: #f9fbf9;
+            text-align: center;
+            border: 1px dashed #cde3d2;
+            color: #4f6f58;
+        }
+        @media (max-width: 992px) {
+            .shipping-layout {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+@php
+    use App\Support\LayoutSettings;
+
+    $navigation = LayoutSettings::navigation($theme);
+    $footerConfig = LayoutSettings::footer($theme);
+    $contact = $shippingData['contact'] ?? [];
+    $address = $shippingData['address'] ?? [];
+    $selection = $shippingData['selection'] ?? [];
+    $selectedCourier = old('shipping_courier', $selection['courier'] ?? '');
+    $selectedService = old('shipping_service', $selection['service'] ?? '');
+    $shippingCost = old('shipping_cost', $shippingData['cost'] ?? 0);
+@endphp
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
+
+<section id="shipping-page">
+    <div class="shipping-layout">
+        <div class="shipping-card">
+            <h2>Informasi Pengiriman</h2>
+            @if ($errors->any())
+                <div class="alert alert-error">
+                    Mohon periksa kembali isian Anda.
+                </div>
+            @endif
+            <form id="shipping-form" method="POST" action="{{ route('checkout.shipping.store') }}">
+                @csrf
+                <div class="form-grid">
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="contact_name">Nama Penerima</label>
+                            <input type="text" id="contact_name" name="contact_name" value="{{ old('contact_name', $contact['name'] ?? '') }}" required>
+                        </div>
+                        <div class="form-field">
+                            <label for="contact_phone">No. Telepon</label>
+                            <input type="text" id="contact_phone" name="contact_phone" value="{{ old('contact_phone', $contact['phone'] ?? '') }}" required>
+                        </div>
+                    </div>
+                    <div class="form-field">
+                        <label for="contact_email">Email</label>
+                        <input type="email" id="contact_email" name="contact_email" value="{{ old('contact_email', $contact['email'] ?? '') }}" required>
+                    </div>
+                    <div class="form-field">
+                        <label for="address">Alamat Lengkap</label>
+                        <textarea id="address" name="address" required>{{ old('address', $address['street'] ?? '') }}</textarea>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="province">Provinsi</label>
+                            <select id="province" name="province_code" required>
+                                <option value="">Pilih Provinsi</option>
+                                @foreach($provinces as $province)
+                                    <option value="{{ $province['code'] }}" @selected(old('province_code', $address['province_code'] ?? '') === $province['code'])>{{ $province['name'] }}</option>
+                                @endforeach
+                            </select>
+                            <input type="hidden" name="province_name" id="province_name" value="{{ old('province_name', $address['province_name'] ?? '') }}">
+                        </div>
+                        <div class="form-field">
+                            <label for="regency">Kota/Kabupaten</label>
+                            <select id="regency" name="regency_code" required>
+                                <option value="">Pilih Kota/Kabupaten</option>
+                            </select>
+                            <input type="hidden" name="regency_name" id="regency_name" value="{{ old('regency_name', $address['regency_name'] ?? '') }}">
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="district">Kecamatan</label>
+                            <select id="district" name="district_code">
+                                <option value="">Pilih Kecamatan</option>
+                            </select>
+                            <input type="hidden" name="district_name" id="district_name" value="{{ old('district_name', $address['district_name'] ?? '') }}">
+                        </div>
+                        <div class="form-field">
+                            <label for="village">Kelurahan</label>
+                            <select id="village" name="village_code">
+                                <option value="">Pilih Kelurahan</option>
+                            </select>
+                            <input type="hidden" name="village_name" id="village_name" value="{{ old('village_name', $address['village_name'] ?? '') }}">
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="postal_code">Kode Pos</label>
+                            <input type="text" id="postal_code" name="postal_code" value="{{ old('postal_code', $address['postal_code'] ?? '') }}" required>
+                        </div>
+                        <div class="form-field">
+                            <label for="shipping_note">Catatan</label>
+                            <input type="text" id="shipping_note" name="shipping_description" value="{{ old('shipping_description', $selection['description'] ?? '') }}">
+                        </div>
+                    </div>
+                </div>
+
+                <input type="hidden" name="shipping_courier" id="shipping_courier" value="{{ $selectedCourier }}">
+                <input type="hidden" name="shipping_service" id="shipping_service" value="{{ $selectedService }}">
+                <input type="hidden" name="shipping_cost" id="shipping_cost" value="{{ $shippingCost }}">
+                <input type="hidden" name="shipping_etd" id="shipping_etd" value="{{ old('shipping_etd', $selection['etd'] ?? '') }}">
+
+                <div class="shipping-methods" id="shipping-methods">
+                    <div class="empty-state" data-methods-empty>
+                        Pilih alamat lengkap untuk melihat pilihan pengiriman.
+                    </div>
+                </div>
+            </form>
+        </div>
+        <aside class="shipping-card">
+            <h2>Ringkasan Pesanan</h2>
+            <div class="shipping-summary">
+                <div class="summary-items">
+                    @foreach($cartSummary['items'] as $item)
+                        <div class="summary-row">
+                            <div>
+                                <strong>{{ $item['name'] }}</strong>
+                                <div class="small text-muted">x{{ $item['quantity'] }}</div>
+                            </div>
+                            <div>Rp {{ $item['subtotal_formatted'] }}</div>
+                        </div>
+                    @endforeach
+                    <div class="summary-row">
+                        <span>Subtotal</span>
+                        <span>Rp {{ $cartSummary['total_price_formatted'] }}</span>
+                    </div>
+                    <div class="summary-row">
+                        <span>Ongkos Kirim</span>
+                        <span id="shipping-cost-display">Rp {{ number_format($shippingCost, 0, ',', '.') }}</span>
+                    </div>
+                    <div class="summary-row total-row">
+                        <span>Total</span>
+                        <span id="grand-total-display">Rp {{ number_format($cartSummary['total_price'] + $shippingCost, 0, ',', '.') }}</span>
+                    </div>
+                </div>
+                <button type="submit" form="shipping-form" class="checkout-button">Lanjut ke Pembayaran</button>
+                <div class="alert alert-info" id="shipping-feedback" style="display:none;"></div>
+            </div>
+        </aside>
+    </div>
+</section>
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+{!! view()->file(base_path('themes/theme-herbalgreen/views/shipping-script.blade.php'), [
+    'cartSummary' => $cartSummary,
+    'address' => $address,
+    'selectedCourier' => $selectedCourier,
+    'selectedService' => $selectedService,
+])->render() !!}
+</body>
+</html>

--- a/themes/theme-restoran/views/order.blade.php
+++ b/themes/theme-restoran/views/order.blade.php
@@ -152,11 +152,13 @@
                     $statusLabel = match($shippingStatus) {
                         'delivered' => 'Tiba di tujuan',
                         'in_transit' => 'Dalam Pengiriman',
+                        'cancelled' => 'Dibatalkan',
                         default => 'Sedang Diproses',
                     };
                     $statusClass = match($shippingStatus) {
                         'delivered' => 'success',
                         'in_transit' => 'warning',
+                        'cancelled' => 'danger',
                         default => 'info',
                     };
                 } else {
@@ -215,8 +217,16 @@
                     </table>
                 </div>
 
-                <div class="d-flex justify-content-between flex-wrap align-items-center pt-3 mt-3 border-top">
-                    <p class="mb-0 text-muted">Total Produk: {{ $order->items->sum('quantity') }}</p>
+                <div class="d-flex flex-column flex-md-row justify-content-between flex-wrap align-items-start gap-2 pt-3 mt-3 border-top">
+                    <div>
+                        <p class="mb-1 text-muted">Total Produk: {{ $order->items->sum('quantity') }}</p>
+                        @if($shippingEnabled)
+                            <p class="mb-1 text-muted">Kurir: {{ strtoupper($order->shipping->courier ?? 'Belum ditentukan') }} {{ $order->shipping->service ? '('.$order->shipping->service.')' : '' }}</p>
+                            <p class="mb-1 text-muted">Ongkir: Rp {{ number_format($order->shipping->cost ?? 0, 0, ',', '.') }}</p>
+                            <p class="mb-1 text-muted">Resi: {{ $order->shipping->tracking_number ?? 'Belum tersedia' }}</p>
+                            <p class="mb-0 text-muted">Status Pengiriman: {{ ucfirst(str_replace('_', ' ', $order->shipping->status ?? 'pending')) }}</p>
+                        @endif
+                    </div>
                     <h5 class="mb-0">Total Pembayaran: Rp {{ number_format($order->total_price ?? 0, 0, ',', '.') }}</h5>
                 </div>
             </div>

--- a/themes/theme-restoran/views/payment.blade.php
+++ b/themes/theme-restoran/views/payment.blade.php
@@ -89,10 +89,21 @@
                                 <span class="fw-semibold">Rp {{ $item['subtotal_formatted'] }}</span>
                             </div>
                         @endforeach
+                        @if($shippingEnabled)
+                            <div class="list-group-item d-flex justify-content-between align-items-start px-0">
+                                <div>
+                                    <h6 class="mb-1">Ongkos Kirim</h6>
+                                    @if(!empty($shippingData['selection']))
+                                        <small class="text-muted">{{ strtoupper($shippingData['selection']['courier'] ?? '') }} • {{ $shippingData['selection']['service'] ?? '' }}</small>
+                                    @endif
+                                </div>
+                                <span class="fw-semibold">Rp {{ $cartSummary['shipping_cost_formatted'] ?? '0' }}</span>
+                            </div>
+                        @endif
                     </div>
                     <div class="d-flex justify-content-between align-items-center border-top pt-3">
                         <span class="fs-5 fw-semibold">Total</span>
-                        <span class="fs-4 fw-bold text-primary">Rp {{ $cartSummary['total_price_formatted'] ?? '0' }}</span>
+                        <span class="fs-4 fw-bold text-primary">Rp {{ $cartSummary['grand_total_formatted'] ?? ($cartSummary['total_price_formatted'] ?? '0') }}</span>
                     </div>
                 </div>
             </div>
@@ -137,6 +148,9 @@
                         @endif
                         @if(!empty($publicConfig['va']))
                             <div><strong>Virtual Account:</strong> {{ $publicConfig['va'] }}</div>
+                        @endif
+                        @if($shippingEnabled && !empty($shippingData['selection']))
+                            <div><strong>Pengiriman:</strong> {{ strtoupper($shippingData['selection']['courier'] ?? '') }} - {{ $shippingData['selection']['service'] ?? '' }} (Rp {{ $cartSummary['shipping_cost_formatted'] ?? '0' }})</div>
                         @endif
                     </div>
                     <div class="mt-auto">

--- a/themes/theme-restoran/views/shipping/rajaongkir.blade.php
+++ b/themes/theme-restoran/views/shipping/rajaongkir.blade.php
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>Pengiriman</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+    <style>
+        body {
+            background: #fff9f3;
+        }
+        #shipping-page {
+            padding: 3rem 2rem;
+        }
+        .shipping-layout {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: grid;
+            grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+            gap: 2rem;
+        }
+        .shipping-card {
+            background: #ffffff;
+            border-radius: 16px;
+            box-shadow: 0 8px 30px rgba(149, 89, 38, 0.12);
+            padding: 2rem;
+        }
+        .shipping-card h2 {
+            margin-top: 0;
+            margin-bottom: 1.5rem;
+            font-size: 1.45rem;
+            color: #b75b26;
+        }
+        label {
+            display: block;
+            font-weight: 600;
+            color: #7a4928;
+            margin-bottom: .45rem;
+        }
+        input, select, textarea {
+            width: 100%;
+            border-radius: 12px;
+            border: 1px solid #f0d5c2;
+            background: #fffaf6;
+            padding: 0.85rem 1rem;
+            font-size: 0.95rem;
+        }
+        textarea { min-height: 110px; resize: vertical; }
+        .form-grid { display: grid; gap: 1.25rem; }
+        .form-row { display: flex; gap: 1rem; }
+        .form-field { flex: 1; }
+        .shipping-methods { display: grid; gap: 1rem; margin-top: 1.5rem; }
+        .shipping-method {
+            border: 1px solid #f3d9c7;
+            border-radius: 14px;
+            padding: 1rem 1.2rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            cursor: pointer;
+            transition: border-color .2s ease, box-shadow .2s ease;
+        }
+        .shipping-method.active {
+            border-color: #b75b26;
+            box-shadow: 0 10px 26px rgba(183, 91, 38, 0.18);
+        }
+        .summary-panel {
+            display: grid;
+            gap: 1rem;
+        }
+        .summary-items {
+            border: 1px solid #f3d9c7;
+            border-radius: 14px;
+            padding: 1.5rem;
+            background: #fffaf6;
+        }
+        .summary-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: .75rem;
+        }
+        .summary-row:last-child { margin-bottom: 0; }
+        .total-row {
+            border-top: 1px dashed #e3c3af;
+            padding-top: 1rem;
+            font-weight: 700;
+            font-size: 1.15rem;
+            color: #b75b26;
+        }
+        .checkout-button {
+            border: none;
+            background: #b75b26;
+            color: #fff;
+            font-weight: 600;
+            border-radius: 999px;
+            padding: 1rem 1.5rem;
+            width: 100%;
+            cursor: pointer;
+        }
+        .alert {
+            padding: .8rem 1rem;
+            border-radius: 12px;
+            font-weight: 600;
+        }
+        .alert-error { background: rgba(220, 53, 69, 0.12); color: #a52a2a; border: 1px solid rgba(220,53,69,0.24); }
+        .alert-info { background: rgba(255, 193, 7, 0.16); color: #7a4c00; border: 1px solid rgba(255,193,7,0.28); }
+        .empty-state { padding: 1.5rem; text-align: center; border: 1px dashed #f0d5c2; border-radius: 14px; color: #8b5a3c; background: #fff3e6; }
+        @media (max-width: 992px) {
+            .shipping-layout { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+@php
+    use App\Support\LayoutSettings;
+
+    $navigation = LayoutSettings::navigation($theme);
+    $footerConfig = LayoutSettings::footer($theme);
+    $contact = $shippingData['contact'] ?? [];
+    $address = $shippingData['address'] ?? [];
+    $selection = $shippingData['selection'] ?? [];
+    $selectedCourier = old('shipping_courier', $selection['courier'] ?? '');
+    $selectedService = old('shipping_service', $selection['service'] ?? '');
+    $shippingCost = old('shipping_cost', $shippingData['cost'] ?? 0);
+@endphp
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
+
+<section id="shipping-page">
+    <div class="shipping-layout">
+        <div class="shipping-card">
+            <h2>Data Pengiriman</h2>
+            @if ($errors->any())
+                <div class="alert alert-error">Mohon lengkapi informasi yang dibutuhkan.</div>
+            @endif
+            <form id="shipping-form" method="POST" action="{{ route('checkout.shipping.store') }}">
+                @csrf
+                <div class="form-grid">
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="contact_name">Nama Penerima</label>
+                            <input type="text" id="contact_name" name="contact_name" value="{{ old('contact_name', $contact['name'] ?? '') }}" required>
+                        </div>
+                        <div class="form-field">
+                            <label for="contact_phone">Telepon</label>
+                            <input type="text" id="contact_phone" name="contact_phone" value="{{ old('contact_phone', $contact['phone'] ?? '') }}" required>
+                        </div>
+                    </div>
+                    <div class="form-field">
+                        <label for="contact_email">Email</label>
+                        <input type="email" id="contact_email" name="contact_email" value="{{ old('contact_email', $contact['email'] ?? '') }}" required>
+                    </div>
+                    <div class="form-field">
+                        <label for="address">Alamat Lengkap</label>
+                        <textarea id="address" name="address" required>{{ old('address', $address['street'] ?? '') }}</textarea>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="province">Provinsi</label>
+                            <select id="province" name="province_code" required>
+                                <option value="">Pilih Provinsi</option>
+                                @foreach($provinces as $province)
+                                    <option value="{{ $province['code'] }}" @selected(old('province_code', $address['province_code'] ?? '') === $province['code'])>{{ $province['name'] }}</option>
+                                @endforeach
+                            </select>
+                            <input type="hidden" id="province_name" name="province_name" value="{{ old('province_name', $address['province_name'] ?? '') }}">
+                        </div>
+                        <div class="form-field">
+                            <label for="regency">Kota/Kabupaten</label>
+                            <select id="regency" name="regency_code" required>
+                                <option value="">Pilih Kota/Kabupaten</option>
+                            </select>
+                            <input type="hidden" id="regency_name" name="regency_name" value="{{ old('regency_name', $address['regency_name'] ?? '') }}">
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="district">Kecamatan</label>
+                            <select id="district" name="district_code">
+                                <option value="">Pilih Kecamatan</option>
+                            </select>
+                            <input type="hidden" id="district_name" name="district_name" value="{{ old('district_name', $address['district_name'] ?? '') }}">
+                        </div>
+                        <div class="form-field">
+                            <label for="village">Kelurahan</label>
+                            <select id="village" name="village_code">
+                                <option value="">Pilih Kelurahan</option>
+                            </select>
+                            <input type="hidden" id="village_name" name="village_name" value="{{ old('village_name', $address['village_name'] ?? '') }}">
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="postal_code">Kode Pos</label>
+                            <input type="text" id="postal_code" name="postal_code" value="{{ old('postal_code', $address['postal_code'] ?? '') }}" required>
+                        </div>
+                        <div class="form-field">
+                            <label for="shipping_note">Catatan</label>
+                            <input type="text" id="shipping_note" name="shipping_description" value="{{ old('shipping_description', $selection['description'] ?? '') }}">
+                        </div>
+                    </div>
+                </div>
+
+                <input type="hidden" name="shipping_courier" id="shipping_courier" value="{{ $selectedCourier }}">
+                <input type="hidden" name="shipping_service" id="shipping_service" value="{{ $selectedService }}">
+                <input type="hidden" name="shipping_cost" id="shipping_cost" value="{{ $shippingCost }}">
+                <input type="hidden" name="shipping_etd" id="shipping_etd" value="{{ old('shipping_etd', $selection['etd'] ?? '') }}">
+
+                <div class="shipping-methods" id="shipping-methods">
+                    <div class="empty-state" data-methods-empty>
+                        Lengkapi alamat untuk menampilkan opsi pengiriman.
+                    </div>
+                </div>
+            </form>
+        </div>
+        <aside class="shipping-card">
+            <h2>Ringkasan</h2>
+            <div class="summary-panel">
+                <div class="summary-items">
+                    @foreach($cartSummary['items'] as $item)
+                        <div class="summary-row">
+                            <div>
+                                <strong>{{ $item['name'] }}</strong>
+                                <div class="small text-muted">x{{ $item['quantity'] }}</div>
+                            </div>
+                            <div>Rp {{ $item['subtotal_formatted'] }}</div>
+                        </div>
+                    @endforeach
+                    <div class="summary-row">
+                        <span>Subtotal</span>
+                        <span>Rp {{ $cartSummary['total_price_formatted'] }}</span>
+                    </div>
+                    <div class="summary-row">
+                        <span>Ongkos Kirim</span>
+                        <span id="shipping-cost-display">Rp {{ number_format($shippingCost, 0, ',', '.') }}</span>
+                    </div>
+                    <div class="summary-row total-row">
+                        <span>Total</span>
+                        <span id="grand-total-display">Rp {{ number_format($cartSummary['total_price'] + $shippingCost, 0, ',', '.') }}</span>
+                    </div>
+                </div>
+                <button type="submit" form="shipping-form" class="checkout-button">Lanjut Pembayaran</button>
+                <div class="alert alert-info" id="shipping-feedback" style="display:none;"></div>
+            </div>
+        </aside>
+    </div>
+</section>
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+{!! view()->file(base_path('themes/theme-herbalgreen/views/shipping-script.blade.php'), [
+    'cartSummary' => $cartSummary,
+    'address' => $address,
+    'selectedCourier' => $selectedCourier,
+    'selectedService' => $selectedService,
+])->render() !!}
+</body>
+</html>

--- a/themes/theme-second/views/order.blade.php
+++ b/themes/theme-second/views/order.blade.php
@@ -163,18 +163,21 @@
         @else
             @foreach($orders as $order)
                 @php
-                    $shippingStatus = optional($order->shipping)->status ?? 'packing';
+                    $shippingData = optional($order->shipping);
+                    $shippingStatus = $shippingData->status ?? 'packing';
                     $statusLabel = 'Menunggu Konfirmasi';
                     $statusClass = 'status-badge--info';
                     if($shippingEnabled) {
                         $statusLabel = match($shippingStatus) {
                             'delivered' => 'Selesai',
                             'in_transit' => 'Sedang Dikirim',
+                            'cancelled' => 'Dibatalkan',
                             default => 'Sedang Diproses',
                         };
                         $statusClass = match($shippingStatus) {
                             'delivered' => 'status-badge--success',
                             'in_transit' => 'status-badge--warning',
+                            'cancelled' => 'status-badge--danger',
                             default => 'status-badge--info',
                         };
                     } else {
@@ -232,7 +235,15 @@
                         </table>
                     </div>
                     <div class="d-flex justify-content-between align-items-center mt-3">
-                        <div class="text-muted">Total Item: {{ $order->items->sum('quantity') }}</div>
+                        <div>
+                            <div class="text-muted">Total Item: {{ $order->items->sum('quantity') }}</div>
+                            @if($shippingEnabled)
+                                <div class="text-muted">Kurir: {{ strtoupper($shippingData->courier ?? 'Belum ditentukan') }} {{ $shippingData->service ? '(' . $shippingData->service . ')' : '' }}</div>
+                                <div class="text-muted">Ongkir: Rp {{ number_format($shippingData->cost ?? 0, 0, ',', '.') }}</div>
+                                <div class="text-muted">Nomor Resi: {{ $shippingData->tracking_number ?? 'Belum tersedia' }}</div>
+                                <div class="text-muted">Status Pengiriman: {{ ucfirst(str_replace('_', ' ', $shippingData->status ?? 'pending')) }}</div>
+                            @endif
+                        </div>
                         <div class="h5 mb-0">Total Pembayaran: Rp {{ number_format($order->total_price ?? 0, 0, ',', '.') }}</div>
                     </div>
                 </div>

--- a/themes/theme-second/views/payment.blade.php
+++ b/themes/theme-second/views/payment.blade.php
@@ -77,9 +77,20 @@
                             <span>Rp {{ $item['subtotal_formatted'] }}</span>
                         </div>
                     @endforeach
+                    @if($shippingEnabled)
+                        <div class="summary__item">
+                            <div>
+                                <h6>Ongkos Kirim</h6>
+                                @if(!empty($shippingData['selection']))
+                                    <small class="text-muted">{{ strtoupper($shippingData['selection']['courier'] ?? '') }} • {{ $shippingData['selection']['service'] ?? '' }}</small>
+                                @endif
+                            </div>
+                            <span>Rp {{ $cartSummary['shipping_cost_formatted'] ?? '0' }}</span>
+                        </div>
+                    @endif
                     <div class="summary__total">
                         <span>Total Pembayaran</span>
-                        <span>Rp {{ $cartSummary['total_price_formatted'] ?? '0' }}</span>
+                        <span>Rp {{ $cartSummary['grand_total_formatted'] ?? ($cartSummary['total_price_formatted'] ?? '0') }}</span>
                     </div>
                 </div>
             </div>
@@ -119,6 +130,9 @@
                         @endif
                         @if(!empty($publicConfig['va']))
                             <div><strong>Virtual Account:</strong> {{ $publicConfig['va'] }}</div>
+                        @endif
+                        @if($shippingEnabled && !empty($shippingData['selection']))
+                            <div><strong>Pengiriman:</strong> {{ strtoupper($shippingData['selection']['courier'] ?? '') }} - {{ $shippingData['selection']['service'] ?? '' }} (Rp {{ $cartSummary['shipping_cost_formatted'] ?? '0' }})</div>
                         @endif
                     </div>
                     <div class="mt-auto">

--- a/themes/theme-second/views/shipping/rajaongkir.blade.php
+++ b/themes/theme-second/views/shipping/rajaongkir.blade.php
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>Pengiriman</title>
+    <link rel="stylesheet" href="{{ asset('themes/' . $theme . '/theme.css') }}">
+    <style>
+        body {
+            background: #f4f6fb;
+        }
+        #shipping-page {
+            padding: 3rem 2rem 4rem;
+        }
+        .shipping-layout {
+            max-width: 1140px;
+            margin: 0 auto;
+            display: grid;
+            grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+            gap: 2.2rem;
+        }
+        .shipping-card {
+            background: #ffffff;
+            border-radius: 20px;
+            box-shadow: 0 20px 40px rgba(34,51,84,0.12);
+            padding: 2.2rem;
+        }
+        .shipping-card h2 {
+            margin-top: 0;
+            font-size: 1.5rem;
+            margin-bottom: 1.5rem;
+            color: #2a3d66;
+        }
+        .form-grid { display: grid; gap: 1.4rem; }
+        .form-row { display: flex; gap: 1rem; }
+        .form-field { flex: 1; }
+        label { font-weight: 600; color: #2a3d66; display: block; margin-bottom: .5rem; }
+        input, select, textarea {
+            width: 100%;
+            border-radius: 14px;
+            border: 1px solid #d6dff6;
+            background: #f8faff;
+            padding: 0.9rem 1rem;
+            font-size: 0.95rem;
+        }
+        textarea { min-height: 110px; resize: vertical; }
+        .shipping-methods { display: grid; gap: 1rem; margin-top: 1.5rem; }
+        .shipping-method {
+            border: 1px solid #e0e7ff;
+            border-radius: 16px;
+            padding: 1rem 1.25rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            cursor: pointer;
+            transition: border-color .2s ease, box-shadow .2s ease;
+        }
+        .shipping-method.active {
+            border-color: #5160ff;
+            box-shadow: 0 16px 30px rgba(81,96,255,0.15);
+        }
+        .summary-panel { display: grid; gap: 1.2rem; }
+        .summary-items {
+            border: 1px solid #e0e7ff;
+            border-radius: 18px;
+            background: linear-gradient(145deg, #ffffff, #f5f7ff);
+            padding: 1.5rem;
+        }
+        .summary-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: .9rem; }
+        .summary-row:last-child { margin-bottom: 0; }
+        .summary-row strong { color: #2a3d66; }
+        .total-row { border-top: 1px dashed #c7d0f8; padding-top: 1rem; font-weight: 700; font-size: 1.2rem; color: #5160ff; }
+        .checkout-button {
+            border: none;
+            border-radius: 14px;
+            padding: 1rem 1.5rem;
+            background: linear-gradient(135deg, #5160ff, #6774ff);
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        .alert { padding: .85rem 1rem; border-radius: 14px; font-weight: 600; }
+        .alert-error { background: rgba(239,68,68,0.12); color: #b91c1c; border: 1px solid rgba(239,68,68,0.24); }
+        .alert-info { background: rgba(59,130,246,0.1); color: #1d4ed8; border: 1px solid rgba(59,130,246,0.2); }
+        .empty-state { padding: 1.5rem; text-align: center; border: 1px dashed #d6dff6; border-radius: 16px; color: #42558c; background: #f1f3ff; }
+        @media (max-width: 992px) { .shipping-layout { grid-template-columns: 1fr; } }
+    </style>
+</head>
+<body>
+@php
+    use App\Support\LayoutSettings;
+
+    $navigation = LayoutSettings::navigation($theme);
+    $footerConfig = LayoutSettings::footer($theme);
+    $contact = $shippingData['contact'] ?? [];
+    $address = $shippingData['address'] ?? [];
+    $selection = $shippingData['selection'] ?? [];
+    $selectedCourier = old('shipping_courier', $selection['courier'] ?? '');
+    $selectedService = old('shipping_service', $selection['service'] ?? '');
+    $shippingCost = old('shipping_cost', $shippingData['cost'] ?? 0);
+@endphp
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/nav-menu.blade.php'), [
+    'brand' => $navigation['brand'],
+    'links' => $navigation['links'],
+    'showCart' => $navigation['show_cart'],
+    'showLogin' => $navigation['show_login'],
+    'cart' => $cartSummary,
+])->render() !!}
+
+<section id="shipping-page">
+    <div class="shipping-layout">
+        <div class="shipping-card">
+            <h2>Alamat Pengiriman</h2>
+            @if($errors->any())
+                <div class="alert alert-error">Terdapat kesalahan pada formulir. Silakan periksa kembali.</div>
+            @endif
+            <form id="shipping-form" method="POST" action="{{ route('checkout.shipping.store') }}">
+                @csrf
+                <div class="form-grid">
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="contact_name">Nama Penerima</label>
+                            <input type="text" id="contact_name" name="contact_name" value="{{ old('contact_name', $contact['name'] ?? '') }}" required>
+                        </div>
+                        <div class="form-field">
+                            <label for="contact_phone">No. Telepon</label>
+                            <input type="text" id="contact_phone" name="contact_phone" value="{{ old('contact_phone', $contact['phone'] ?? '') }}" required>
+                        </div>
+                    </div>
+                    <div class="form-field">
+                        <label for="contact_email">Email</label>
+                        <input type="email" id="contact_email" name="contact_email" value="{{ old('contact_email', $contact['email'] ?? '') }}" required>
+                    </div>
+                    <div class="form-field">
+                        <label for="address">Alamat Lengkap</label>
+                        <textarea id="address" name="address" required>{{ old('address', $address['street'] ?? '') }}</textarea>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="province">Provinsi</label>
+                            <select id="province" name="province_code" required>
+                                <option value="">Pilih Provinsi</option>
+                                @foreach($provinces as $province)
+                                    <option value="{{ $province['code'] }}" @selected(old('province_code', $address['province_code'] ?? '') === $province['code'])>{{ $province['name'] }}</option>
+                                @endforeach
+                            </select>
+                            <input type="hidden" id="province_name" name="province_name" value="{{ old('province_name', $address['province_name'] ?? '') }}">
+                        </div>
+                        <div class="form-field">
+                            <label for="regency">Kota/Kabupaten</label>
+                            <select id="regency" name="regency_code" required>
+                                <option value="">Pilih Kota/Kabupaten</option>
+                            </select>
+                            <input type="hidden" id="regency_name" name="regency_name" value="{{ old('regency_name', $address['regency_name'] ?? '') }}">
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="district">Kecamatan</label>
+                            <select id="district" name="district_code">
+                                <option value="">Pilih Kecamatan</option>
+                            </select>
+                            <input type="hidden" id="district_name" name="district_name" value="{{ old('district_name', $address['district_name'] ?? '') }}">
+                        </div>
+                        <div class="form-field">
+                            <label for="village">Kelurahan</label>
+                            <select id="village" name="village_code">
+                                <option value="">Pilih Kelurahan</option>
+                            </select>
+                            <input type="hidden" id="village_name" name="village_name" value="{{ old('village_name', $address['village_name'] ?? '') }}">
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="postal_code">Kode Pos</label>
+                            <input type="text" id="postal_code" name="postal_code" value="{{ old('postal_code', $address['postal_code'] ?? '') }}" required>
+                        </div>
+                        <div class="form-field">
+                            <label for="shipping_note">Catatan</label>
+                            <input type="text" id="shipping_note" name="shipping_description" value="{{ old('shipping_description', $selection['description'] ?? '') }}">
+                        </div>
+                    </div>
+                </div>
+
+                <input type="hidden" name="shipping_courier" id="shipping_courier" value="{{ $selectedCourier }}">
+                <input type="hidden" name="shipping_service" id="shipping_service" value="{{ $selectedService }}">
+                <input type="hidden" name="shipping_cost" id="shipping_cost" value="{{ $shippingCost }}">
+                <input type="hidden" name="shipping_etd" id="shipping_etd" value="{{ old('shipping_etd', $selection['etd'] ?? '') }}">
+
+                <div class="shipping-methods" id="shipping-methods">
+                    <div class="empty-state" data-methods-empty>
+                        Lengkapi alamat pengiriman untuk melihat opsi layanan.
+                    </div>
+                </div>
+            </form>
+        </div>
+        <aside class="shipping-card">
+            <h2>Ringkasan Pesanan</h2>
+            <div class="summary-panel">
+                <div class="summary-items">
+                    @foreach($cartSummary['items'] as $item)
+                        <div class="summary-row">
+                            <div>
+                                <strong>{{ $item['name'] }}</strong>
+                                <div class="small text-muted">x{{ $item['quantity'] }}</div>
+                            </div>
+                            <div>Rp {{ $item['subtotal_formatted'] }}</div>
+                        </div>
+                    @endforeach
+                    <div class="summary-row">
+                        <span>Subtotal</span>
+                        <span>Rp {{ $cartSummary['total_price_formatted'] }}</span>
+                    </div>
+                    <div class="summary-row">
+                        <span>Ongkos Kirim</span>
+                        <span id="shipping-cost-display">Rp {{ number_format($shippingCost, 0, ',', '.') }}</span>
+                    </div>
+                    <div class="summary-row total-row">
+                        <span>Total</span>
+                        <span id="grand-total-display">Rp {{ number_format($cartSummary['total_price'] + $shippingCost, 0, ',', '.') }}</span>
+                    </div>
+                </div>
+                <button type="submit" form="shipping-form" class="checkout-button">Lanjut ke Pembayaran</button>
+                <div class="alert alert-info" id="shipping-feedback" style="display:none;"></div>
+            </div>
+        </aside>
+    </div>
+</section>
+
+{!! view()->file(base_path('themes/' . $theme . '/views/components/footer.blade.php'), [
+    'footer' => $footerConfig,
+])->render() !!}
+
+{!! view()->file(base_path('themes/theme-herbalgreen/views/shipping-script.blade.php'), [
+    'cartSummary' => $cartSummary,
+    'address' => $address,
+    'selectedCourier' => $selectedCourier,
+    'selectedService' => $selectedService,
+])->render() !!}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update cart continue buttons across all storefront themes to link directly to the configured shipping or payment routes while keeping disabled styling states in sync with cart contents
- change the shipping controller to resolve gateway-specific shipping templates and relocate RajaOngkir pages under theme-based gateway folders so future providers can supply unique flows

## Testing
- php artisan test --env=testing *(fails: missing vendor directory in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c1b191b88329a174537b2868b606