### PR TITLE
Improve RajaOngkir destination normalization

### DIFF
--- a/app/Services/Shipping/RajaOngkirShippingGateway.php
+++ b/app/Services/Shipping/RajaOngkirShippingGateway.php
@@ -340,9 +340,16 @@ class RajaOngkirShippingGateway implements ShippingGateway
     protected function normalizeName(string $value): string
     {
         $value = Str::lower($value);
-        $value = str_replace(['kab.', 'kabupaten', 'kota', ' '], '', $value);
-        $value = str_replace(['(', ')', '-'], '', $value);
+        $value = str_replace([
+            'kab.',
+            'kabupaten',
+            'kota',
+            'adm.',
+            'administrasi',
+        ], '', $value);
 
-        return $value;
+        // Remove non-alphanumeric characters to make the comparison resilient to
+        // punctuation differences between local datasets and RajaOngkir.
+        return preg_replace('/[^a-z0-9]/', '', $value);
     }
 }


### PR DESCRIPTION
## Summary
- expand RajaOngkir destination name normalization to drop administrative prefixes and punctuation
- rely on alphanumeric comparison so more regency names map to their RajaOngkir city ids

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e65e4634cc832992a586dca79672d3